### PR TITLE
Cyclone dds print complete/minimal typeid and add unsupported test manifesto

### DIFF
--- a/src/c/cyclone-dds-cmake/CMakeLists.txt
+++ b/src/c/cyclone-dds-cmake/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT BUILD_SHARED_LIBS)
     find_package(OpenSSL REQUIRED)
 endif()
 find_package(CycloneDDS REQUIRED)
-set(EXECUTABLE_NAME "eclipse_cyclone-${CycloneDDS_VERSION}_linux")
+set(EXECUTABLE_NAME "eclipse_cyclone-${CycloneDDS_VERSION}_test_main_linux")
 
 add_executable(${EXECUTABLE_NAME} ../test_main.c
     ${CMAKE_PREFIX_PATH}/share/CycloneDDS/examples/dynsub/dyntypelib.c

--- a/src/c/test_main.c
+++ b/src/c/test_main.c
@@ -1161,7 +1161,7 @@ bool TestApplication_initialize(TestApplication *app, TestOptions *options)
 
     if (options->print_typeid)
     {
-        print_typeid(app->dt, options->type_object_version);
+        print_typeid(app->dt, app->dtl, options->type_object_version);
     }
 
     //if ((retcode = dds_dynamic_type_register(app->dt->dtype, &app->dt->typeinfo)) != DDS_RETCODE_OK)

--- a/src/c/variant_eclipse_cyclone_dds.h
+++ b/src/c/variant_eclipse_cyclone_dds.h
@@ -1,4 +1,5 @@
 #include "dds/dds.h"
+#include "dds/ddsi/ddsi_typelib.h"
 #include "dds/../../share/CycloneDDS/examples/dynsub/dyntypelib.h"
 #include "dds/../../share/CycloneDDS/examples/dynsub/domtree.h"
 #include "dds/../../share/CycloneDDS/examples/dynsub/dynsub.h"
@@ -117,17 +118,30 @@ bool check_data(void        *dynamic_sample,
   return retval;
 }
 
-void print_typeid(struct dyntype *dt, int version) {
+static void shift_typeid(char* str) {
+  int i = 0;
+  while(str[i] != ' ' && i < 50) i++;
+  if (i == 50) return;
+  i++;
+  int j = i;
+  while(str[j] != ']')
+  {
+    str[j - i] = str[j];
+    j++;
+  }
+  str[j - i] = '\0';
+}
+
+void print_typeid(struct dyntype *dt, struct dyntypelib *dtl, int version) {
     const DDS_XTypes_EquivalenceHash *id = &((DDS_XTypes_TypeInformation *)dt->typeinfo)->minimal.typeid_with_size.type_id._u.equivalence_hash;
-    printf("Complete Type Object V%d - Type ID: %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n", version,
-             (unsigned) (*id)[0], (unsigned) (*id)[1], (unsigned) (*id)[2], (unsigned) (*id)[3],
-             (unsigned) (*id)[4], (unsigned) (*id)[5], (unsigned) (*id)[6], (unsigned) (*id)[7],
-             (unsigned) (*id)[8], (unsigned) (*id)[9], (unsigned) (*id)[10], (unsigned) (*id)[11],
-             (unsigned) (*id)[12], (unsigned) (*id)[13]);
-    id = &((DDS_XTypes_TypeInformation *)dt->typeinfo)->minimal.typeid_with_size.type_id._u.equivalence_hash;
-    printf("Minimal Type Object V%d - Type ID: %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n", version,
-             (unsigned) (*id)[0], (unsigned) (*id)[1], (unsigned) (*id)[2], (unsigned) (*id)[3],
-             (unsigned) (*id)[4], (unsigned) (*id)[5], (unsigned) (*id)[6], (unsigned) (*id)[7],
-             (unsigned) (*id)[8], (unsigned) (*id)[9], (unsigned) (*id)[10], (unsigned) (*id)[11],
-             (unsigned) (*id)[12], (unsigned) (*id)[13]);
+    struct ddsi_typeid_str strm, strc;
+    const ddsi_typeid_t *type_id_minimal = NULL, *type_id_complete = NULL;
+    type_id_minimal = ddsi_typeinfo_minimal_typeid(dt->typeinfo);
+    type_id_complete = ddsi_typeinfo_complete_typeid(dt->typeinfo);
+    ddsi_make_typeid_str(&strc, type_id_complete);
+    shift_typeid(strc.str);
+    printf("Complete Type Object V%d - Type ID: %s\n", version, strc.str);
+    ddsi_make_typeid_str(&strm, type_id_minimal);
+    shift_typeid(strm.str);
+    printf("Minimal Type Object V%d - Type ID: %s\n", version, strm.str);
 }

--- a/unsupported_test_manifest/eclipse_cyclone-11.0.1.txt
+++ b/unsupported_test_manifest/eclipse_cyclone-11.0.1.txt
@@ -1,0 +1,22 @@
+# Unsupported tests for eclipse_cyclone-11.0.1
+#
+# Format: one full test ID per line.
+# Test ID = <dict_name>_<test_case_name>
+
+# mutable union
+xtypes_v2_struct_test_suite_struct_key_union_1
+xtypes_v2_struct_test_suite_struct_key_union_2
+xtypes_v2_union_test_suite_union_primitives_mutable
+xtypes_v2_union_test_suite_union_final_mutable
+xtypes_v2_union_test_suite_union_appendable_mutable
+xtypes_v2_union_test_suite_union_mutable_one_common
+xtypes_v2_union_test_suite_union_mutable_no_common
+xtypes_v2_union_test_suite_union_mutable_no_common_w_default
+
+# default enum values
+xtypes_v2_tryconstruct_test_suite_tryc_enum_2
+xtypes_v2_tryconstruct_test_suite_tryc_union_enum_2
+xtypes_v2_tryconstruct_test_suite_tryc_union_enum_disc_2
+
+# union discriminator is key
+xtypes_v2_union_test_suite_union_uint32_one_key


### PR DESCRIPTION
CycloneDDS does not support having TypeObjectV1, so I'm not sure how I'm supposed to handle it yet.