### PR TITLE
Install libxerces-c3.2 before running interoperability tests

### DIFF
--- a/.github/workflows/1_run_interoperability_tests.yml
+++ b/.github/workflows/1_run_interoperability_tests.yml
@@ -48,6 +48,10 @@ jobs:
       run: unzip 'zipped_executables/*.zip' -d executables
     - name: Install Python requirements
       run: pip install --requirement requirements.txt
+    - name: Install libxerces-c3.2
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes libxerces-c3.2
     - name: Run Interoperability script
       timeout-minutes: 120
       continue-on-error: true


### PR DESCRIPTION
The XML type driver needs Xerces-C at runtime, so install it from Ubuntu's apt repository as a distinct step in run_tests.