### PR TITLE
Add CLA for HDDS (Naskel)

### DIFF
--- a/CLA/CLA_HDDS.md
+++ b/CLA/CLA_HDDS.md
@@ -1,0 +1,60 @@
+# OMG DDS INTEROPERABILITY REPOSITORY - CONTRIBUTOR LICENSE AGREEMENT
+
+**This Contributor License Agreement ("Agreement") specifies the terms under which the individual or corporate entity specified in the signature block below ("You") agree to make intellectual property contributions to the OMG DDS Interoperability Repository.   BY SIGNING BELOW YOU ARE AGREEING TO BE BOUND BY THE TERMS OF THIS AGREEMENT. If You are signing this Agreement in Your capacity as an employee, THEN YOUR EMPLOYER AND YOU ARE BOTH BOUND BY THIS AGREEMENT.**
+
+1. Definitions
+
+    1. "OMG DDS Xtypes Interoperability Repository" (or "Repository") means the Git repository [https://github.com/omg-dds/dds-xtypes](https://github.com/omg-dds/dds-xtypes).
+
+    2. "Moderator" means an entity or individual responsible for authorizing changes to the Repository.
+
+    3. "Submit" (or "Submitted") means any submission, including source code, binaries, code, pull requests, issue reports, comments, etc., made to the Moderators for inclusion in the Repository either through the Git repository interface or through electronic file transfer.
+
+    4. A "Contribution" is any original work of authorship, including any modifications or additions to an existing work, that You Submit to the DDS Interoperability Repository.
+
+    5. A "User" is anyone who accesses the Repository.
+
+2. Allowable Contribution Representations
+
+    1. You represent that You have the necessary rights to the Contribution(s) to meet the obligations of this Agreement.  If You are employed, Your employer has authorized Contribution(s) under this Agreement.
+
+    2. You represent that you have no knowledge of third-party intellectual property rights that are likely to be infringed by the Contribution(s).  You represent that you have no knowledge that such infringement or any allegation of misappropriation of intellectual property rights is likely to be claimed or has already been claimed.
+
+3. License
+
+    You grant Moderators a perpetual, worldwide, non-exclusive, assignable, paid-up license to publish, display, and redistribute the Contribution as part of the Repository.  You also license to Moderators under the same terms any other intellectual property rights required to publish, display, and redistribute the Contributions as part of the Repository.  You further grant all Users of the Repository a license to the Contribution under the terms of the [OMG DDS Interoperability Testing License](../LICENSE.md) included in the Repository.  Moderators are under no obligation to publish Contributions.
+
+4. No Warranty, Consequential Damages.  Limited Liability
+
+    Other than explicitly stated herein, You provide the Contribution(s) "as is" with no warranty nor claims of fitness to any purpose.  Neither party shall be liable for consequential or special damages of any kind.  Other than for breach of warranty or representations herein, the liability of either party to the other shall be limited to $1000.
+
+5. General
+
+    1. If You are an agency of the United States Government, then this Agreement will be governed by the United States federal common law.  Otherwise, this Agreement will be governed by the laws of the State of California except with regard to its choice of law rules.
+
+    2. A party may assign this Agreement to an entity acquiring essentially all of the party's relevant business.
+
+6. Electronic Signatures
+
+    "Electronic Signature" means any electronic sound, symbol, or process attached to or logically associated with a record and executed and adopted by a party with the intent to sign such record.
+
+    Each party agrees that the Electronic Signatures, whether digital or encrypted, of the parties included in this Agreement are intended to authenticate this writing and to have the same force and effect as manual signatures.
+
+
+IN WITNESS WHEREOF, You, intending to be legally bound, have executed this Agreement or caused Your employer's proper and duly authorized officer to execute and deliver this Agreement, for good and valuable consideration, the sufficiency of which is hereby acknowledged, as of the day and year first written below.
+
+**For:**
+
+Entity Name: Olivier Esteve
+
+Address: Loiret, France
+
+ ("**You**")
+
+**By:**
+
+Name: Olivier Esteve
+
+Title: Founder, naskel.com
+
+Date: July 10, 2026


### PR DESCRIPTION
Adds the signed Contributor License Agreement for HDDS (Naskel) under `CLA/CLA_HDDS.md`, per CONTRIBUTING.md, to enable HDDS's participation in the DDS-XTypes interoperability tests.

HDDS is an independent, clean-room pure-Rust DDS implementation.