### PR TITLE
Add CLA and application code for HDDS (Naskel)

### DIFF
--- a/CLA/CLA_HDDS.md
+++ b/CLA/CLA_HDDS.md
@@ -1,0 +1,60 @@
+# OMG DDS INTEROPERABILITY REPOSITORY - CONTRIBUTOR LICENSE AGREEMENT
+
+**This Contributor License Agreement ("Agreement") specifies the terms under which the individual or corporate entity specified in the signature block below ("You") agree to make intellectual property contributions to the OMG DDS Interoperability Repository.   BY SIGNING BELOW YOU ARE AGREEING TO BE BOUND BY THE TERMS OF THIS AGREEMENT. If You are signing this Agreement in Your capacity as an employee, THEN YOUR EMPLOYER AND YOU ARE BOTH BOUND BY THIS AGREEMENT.**
+
+1. Definitions
+
+    1. "OMG DDS Xtypes Interoperability Repository" (or "Repository") means the Git repository [https://github.com/omg-dds/dds-xtypes](https://github.com/omg-dds/dds-xtypes).
+
+    2. "Moderator" means an entity or individual responsible for authorizing changes to the Repository.
+
+    3. "Submit" (or "Submitted") means any submission, including source code, binaries, code, pull requests, issue reports, comments, etc., made to the Moderators for inclusion in the Repository either through the Git repository interface or through electronic file transfer.
+
+    4. A "Contribution" is any original work of authorship, including any modifications or additions to an existing work, that You Submit to the DDS Interoperability Repository.
+
+    5. A "User" is anyone who accesses the Repository.
+
+2. Allowable Contribution Representations
+
+    1. You represent that You have the necessary rights to the Contribution(s) to meet the obligations of this Agreement.  If You are employed, Your employer has authorized Contribution(s) under this Agreement.
+
+    2. You represent that you have no knowledge of third-party intellectual property rights that are likely to be infringed by the Contribution(s).  You represent that you have no knowledge that such infringement or any allegation of misappropriation of intellectual property rights is likely to be claimed or has already been claimed.
+
+3. License
+
+    You grant Moderators a perpetual, worldwide, non-exclusive, assignable, paid-up license to publish, display, and redistribute the Contribution as part of the Repository.  You also license to Moderators under the same terms any other intellectual property rights required to publish, display, and redistribute the Contributions as part of the Repository.  You further grant all Users of the Repository a license to the Contribution under the terms of the [OMG DDS Interoperability Testing License](../LICENSE.md) included in the Repository.  Moderators are under no obligation to publish Contributions.
+
+4. No Warranty, Consequential Damages.  Limited Liability
+
+    Other than explicitly stated herein, You provide the Contribution(s) "as is" with no warranty nor claims of fitness to any purpose.  Neither party shall be liable for consequential or special damages of any kind.  Other than for breach of warranty or representations herein, the liability of either party to the other shall be limited to $1000.
+
+5. General
+
+    1. If You are an agency of the United States Government, then this Agreement will be governed by the United States federal common law.  Otherwise, this Agreement will be governed by the laws of the State of California except with regard to its choice of law rules.
+
+    2. A party may assign this Agreement to an entity acquiring essentially all of the party's relevant business.
+
+6. Electronic Signatures
+
+    "Electronic Signature" means any electronic sound, symbol, or process attached to or logically associated with a record and executed and adopted by a party with the intent to sign such record.
+
+    Each party agrees that the Electronic Signatures, whether digital or encrypted, of the parties included in this Agreement are intended to authenticate this writing and to have the same force and effect as manual signatures.
+
+
+IN WITNESS WHEREOF, You, intending to be legally bound, have executed this Agreement or caused Your employer's proper and duly authorized officer to execute and deliver this Agreement, for good and valuable consideration, the sufficiency of which is hereby acknowledged, as of the day and year first written below.
+
+**For:**
+
+Entity Name: Olivier Esteve
+
+Address: Loiret, France
+
+ ("**You**")
+
+**By:**
+
+Name: Olivier Esteve
+
+Title: Founder, naskel.com
+
+Date: July 10, 2026

--- a/src/rs/HDDS/Cargo.toml
+++ b/src/rs/HDDS/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "hdds-xtypes-interop"
+version = "1.1.5"
+edition = "2021"
+description = "HDDS OMG DDS-XTypes interoperability test application"
+license = "Apache-2.0 OR MIT"
+
+[[bin]]
+name = "hdds_xtypes_shape_main_linux"
+path = "src/main.rs"
+
+# `hdds` is consumed from GitHub by default so CI and external contributors
+# can build without Olivier's working tree. `hdds 1.1.5` is not yet on
+# crates.io (latest published is 1.1.2); pulling `branch = "master"` keeps
+# this binary compiling against the in-flight wire changes needed for OMG
+# interop. Switch to `version = "1.1.5"` once it is published on crates.io.
+# Enable TypeObject-resolver-backed structural assignability (e.g. enum1x10 <-> enum2x10).
+# Build with: --features xtypes-structural-assignability
+# Propagates the same feature name to the hdds crate.
+[features]
+xtypes-structural-assignability = ["hdds/xtypes-structural-assignability"]
+
+[dependencies]
+hdds = { git = "https://github.com/hdds-team/hdds", branch = "master", default-features = false, features = ["xtypes"] }
+quick-xml = "0.36"
+log = "0.4"
+env_logger = "0.11"
+signal-hook = "0.3"
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1
+strip = true

--- a/src/rs/HDDS/src/cdr_compat.rs
+++ b/src/rs/HDDS/src/cdr_compat.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (c) 2025-2026 naskel.com
+
+//! CDR encapsulation header helpers.
+//!
+//! RTPS DATA submessages carry a 4-byte encapsulation header before the
+//! serialized payload (DDS-XTypes v1.3 section 7.6.3.1.2):
+//!
+//!   Byte 0: 0x00 (reserved)
+//!   Byte 1: representation identifier (table below)
+//!   Bytes 2-3: options (usually 0x00 0x00)
+//!
+//! Representation IDs used in the OMG test suite:
+//!
+//!   | Repr ID | Name                  | Notes                                |
+//!   |---------|-----------------------|--------------------------------------|
+//!   | 0x00    | CDR_BE                | XCDR1 big-endian                     |
+//!   | 0x01    | CDR_LE                | XCDR1 little-endian                  |
+//!   | 0x02    | PL_CDR_BE             | XCDR1 with parameter list (mutable)  |
+//!   | 0x03    | PL_CDR_LE             | XCDR1 with parameter list (mutable)  |
+//!   | 0x06    | CDR2_BE               | XCDR2 plain big-endian               |
+//!   | 0x07    | CDR2_LE               | XCDR2 plain little-endian            |
+//!   | 0x08    | D_CDR2_BE             | XCDR2 delimited (appendable)         |
+//!   | 0x09    | D_CDR2_LE             | XCDR2 delimited (appendable)         |
+//!   | 0x0A    | PL_CDR2_BE            | XCDR2 with EMHEADER (mutable)        |
+//!   | 0x0B    | PL_CDR2_LE            | XCDR2 with EMHEADER (mutable)        |
+//!
+//! Extensibility rules (DDS-XTypes v1.3 §7.4.3 Table 12):
+//!   - FINAL      → CDR_LE (0x01) or CDR2_LE (0x07) per xcdr_version flag
+//!   - APPENDABLE → D_CDR2_LE (0x09) — always XCDR2 delimited, xcdr_version ignored
+//!   - MUTABLE    → PL_CDR2_LE (0x0B) — always XCDR2 with EMHEADER, xcdr_version ignored
+//!
+//! Use `prepend_encapsulation_with_ext` when the type descriptor's extensibility
+//! is available (preferred). `prepend_encapsulation` is kept for call-sites that
+//! have not yet been updated to thread the extensibility through.
+
+use hdds::dynamic::Extensibility;
+
+/// Prepend DDS CDR encapsulation header, selecting the representation
+/// identifier from both the xcdr_version preference AND the type extensibility.
+///
+/// Extensibility overrides xcdr_version for APPENDABLE and MUTABLE types:
+///
+/// - `Final`      → CDR_LE (0x01) when xcdr_version == 1, else CDR2_LE (0x07)
+/// - `Appendable` → D_CDR2_LE (0x09) regardless of xcdr_version
+/// - `Mutable`    → PL_CDR2_LE (0x0B) regardless of xcdr_version
+///
+/// DDS-XTypes v1.3 §7.4.3 Table 12.
+pub fn prepend_encapsulation_with_ext(
+    cdr: &[u8],
+    xcdr_version: u8,
+    ext: Extensibility,
+) -> Vec<u8> {
+    let repr_id: u8 = match ext {
+        Extensibility::Final => {
+            if xcdr_version == 1 {
+                0x01 // CDR_LE
+            } else {
+                0x07 // CDR2_LE
+            }
+        }
+        Extensibility::Appendable => 0x09, // D_CDR2_LE
+        Extensibility::Mutable => 0x0B,    // PL_CDR2_LE
+    };
+    build_encapsulation_frame(cdr, repr_id)
+}
+
+/// Prepend DDS CDR encapsulation header without extensibility context.
+///
+/// xcdr_version: 1 selects XCDR1 little-endian (`CDR_LE`, 0x01); any other
+/// value selects XCDR2 plain little-endian (`CDR2_LE`, 0x07).
+///
+/// Callers that know the type descriptor's extensibility should prefer
+/// [`prepend_encapsulation_with_ext`] so that APPENDABLE / MUTABLE types
+/// emit the correct delimited or EMHEADER representation ID.
+pub fn prepend_encapsulation(cdr: &[u8], xcdr_version: u8) -> Vec<u8> {
+    let repr_id: u8 = match xcdr_version {
+        1 => 0x01, // CDR_LE
+        _ => 0x07, // CDR2_LE plain
+    };
+    build_encapsulation_frame(cdr, repr_id)
+}
+
+/// Build the 4-byte encapsulation frame followed by the CDR payload.
+fn build_encapsulation_frame(cdr: &[u8], repr_id: u8) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + cdr.len());
+    out.push(0x00);
+    out.push(repr_id);
+    out.push(0x00);
+    out.push(0x00);
+    out.extend_from_slice(cdr);
+    out
+}
+
+/// Strip DDS CDR encapsulation header if present (4 bytes). Returns the
+/// payload unchanged if no recognized representation ID is found in
+/// byte 1, so callers that receive raw CDR without a header still decode.
+pub fn strip_encapsulation(data: &[u8]) -> &[u8] {
+    if data.len() >= 4 && data[0] == 0x00 {
+        let repr_id = data[1];
+        // All representation IDs from the DDS-XTypes v1.3 table.
+        if matches!(
+            repr_id,
+            0x00 | 0x01 | 0x02 | 0x03 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0A | 0x0B
+        ) {
+            return &data[4..];
+        }
+    }
+    data
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prepend_xcdr1_le() {
+        let p = prepend_encapsulation(&[0xAA, 0xBB], 1);
+        assert_eq!(&p[..4], &[0x00, 0x01, 0x00, 0x00]);
+        assert_eq!(&p[4..], &[0xAA, 0xBB]);
+    }
+
+    #[test]
+    fn prepend_xcdr2_le() {
+        let p = prepend_encapsulation(&[0xCC], 2);
+        assert_eq!(&p[..4], &[0x00, 0x07, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn strip_passes_through_when_no_header() {
+        let raw = [0x42, 0x43, 0x44];
+        assert_eq!(strip_encapsulation(&raw), &[0x42, 0x43, 0x44]);
+    }
+
+    #[test]
+    fn strip_recognizes_all_known_repr_ids() {
+        for rid in [0x00, 0x01, 0x02, 0x03, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B] {
+            let buf = [0x00, rid, 0x00, 0x00, 0x42];
+            let stripped = strip_encapsulation(&buf);
+            assert_eq!(stripped, &[0x42], "repr_id 0x{:02X}", rid);
+        }
+    }
+
+    // -- prepend_encapsulation_with_ext tests ---------------------------------
+
+    #[test]
+    fn with_ext_final_xcdr1_emits_cdr_le() {
+        // FINAL + xcdr_version=1 → CDR_LE (0x01)
+        let p = prepend_encapsulation_with_ext(&[0x01], 1, Extensibility::Final);
+        assert_eq!(p[1], 0x01, "expected CDR_LE repr_id");
+    }
+
+    #[test]
+    fn with_ext_final_xcdr2_emits_cdr2_le() {
+        // FINAL + xcdr_version=2 → CDR2_LE (0x07)
+        let p = prepend_encapsulation_with_ext(&[0x01], 2, Extensibility::Final);
+        assert_eq!(p[1], 0x07, "expected CDR2_LE repr_id");
+    }
+
+    #[test]
+    fn with_ext_appendable_always_emits_d_cdr2_le() {
+        // APPENDABLE must always emit D_CDR2_LE (0x09) per XTypes §7.4.3 Table 12,
+        // regardless of the xcdr_version flag.
+        for xcdr in [1u8, 2, 3] {
+            let p = prepend_encapsulation_with_ext(&[0x01], xcdr, Extensibility::Appendable);
+            assert_eq!(
+                p[1], 0x09,
+                "APPENDABLE must emit D_CDR2_LE (0x09) for xcdr_version={}",
+                xcdr
+            );
+        }
+    }
+
+    #[test]
+    fn with_ext_mutable_always_emits_pl_cdr2_le() {
+        // MUTABLE must always emit PL_CDR2_LE (0x0B) per XTypes §7.4.3 Table 12,
+        // regardless of the xcdr_version flag.
+        for xcdr in [1u8, 2, 3] {
+            let p = prepend_encapsulation_with_ext(&[0x01], xcdr, Extensibility::Mutable);
+            assert_eq!(
+                p[1], 0x0B,
+                "MUTABLE must emit PL_CDR2_LE (0x0B) for xcdr_version={}",
+                xcdr
+            );
+        }
+    }
+}

--- a/src/rs/HDDS/src/data_loader.rs
+++ b/src/rs/HDDS/src/data_loader.rs
@@ -1,0 +1,1565 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (c) 2025-2026 naskel.com
+
+//! DDS-XML data instance loader.
+//!
+//! Parses the OMG dds-xtypes test data XML format and produces a
+//! `DynamicData` whose `TypeDescriptor` matches the provided `type_desc`.
+//!
+//! Scalar struct:
+//!
+//!   <struct>
+//!     <x1>1</x1>
+//!     <x2>2</x2>
+//!   </struct>
+//!
+//! Array / sequence of scalars (uses `<item>`):
+//!
+//!   <struct>
+//!     <x1>
+//!       <item>1</item>
+//!       <item>2</item>
+//!     </x1>
+//!   </struct>
+//!
+//! Nested struct (any name allowed for the outer wrapper):
+//!
+//!   <outer>
+//!     <inner_field>
+//!       <a>1</a>
+//!       <b>2</b>
+//!     </inner_field>
+//!   </outer>
+//!
+//! Union (carries discriminator + selected case):
+//!
+//!   <union_1>
+//!     <discriminator>0x01</discriminator>
+//!     <x1>123</x1>
+//!   </union_1>
+//!
+//! Array of struct / sequence of struct:
+//!
+//!   <outer>
+//!     <list>
+//!       <item><x1>1</x1></item>
+//!       <item><x1>2</x1></item>
+//!     </list>
+//!   </outer>
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use hdds::dynamic::{DynamicData, DynamicValue, PrimitiveKind, TypeDescriptor, TypeKind};
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::reader::Reader;
+
+// ---------------------------------------------------------------------------
+// Public
+// ---------------------------------------------------------------------------
+
+pub fn load_data_from_xml(
+    path: &str,
+    type_desc: &Arc<TypeDescriptor>,
+) -> Result<DynamicData, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read '{}': {}", path, e))?;
+    parse_data_xml(&content, type_desc).map_err(|e| format!("{}: {}", path, e))
+}
+
+/// Compare two DynamicData instances for equality. Symmetric across all
+/// `DynamicValue` variants including `Union`, `WString`, `LongDouble`,
+/// `Null`, and struct field sets.
+pub fn compare_dynamic_data(a: &DynamicData, b: &DynamicData) -> bool {
+    compare_values(a.value(), b.value())
+}
+
+fn compare_values(a: &DynamicValue, b: &DynamicValue) -> bool {
+    match (a, b) {
+        (DynamicValue::Bool(x), DynamicValue::Bool(y)) => x == y,
+        (DynamicValue::U8(x), DynamicValue::U8(y)) => x == y,
+        (DynamicValue::U16(x), DynamicValue::U16(y)) => x == y,
+        (DynamicValue::U32(x), DynamicValue::U32(y)) => x == y,
+        (DynamicValue::U64(x), DynamicValue::U64(y)) => x == y,
+        (DynamicValue::I8(x), DynamicValue::I8(y)) => x == y,
+        (DynamicValue::I16(x), DynamicValue::I16(y)) => x == y,
+        (DynamicValue::I32(x), DynamicValue::I32(y)) => x == y,
+        (DynamicValue::I64(x), DynamicValue::I64(y)) => x == y,
+        // F32/F64: bitwise equality. Floating-point payloads in the OMG
+        // corpus are written as exact decimal literals that round-trip.
+        (DynamicValue::F32(x), DynamicValue::F32(y)) => x.to_bits() == y.to_bits(),
+        (DynamicValue::F64(x), DynamicValue::F64(y)) => x.to_bits() == y.to_bits(),
+        (DynamicValue::Char(x), DynamicValue::Char(y)) => x == y,
+        (DynamicValue::String(x), DynamicValue::String(y)) => x == y,
+        (DynamicValue::WString(x), DynamicValue::WString(y)) => x == y,
+        (DynamicValue::LongDouble(x), DynamicValue::LongDouble(y)) => {
+            long_double_semantically_equal(x, y)
+        }
+        (DynamicValue::Enum(vx, _), DynamicValue::Enum(vy, _)) => vx == vy,
+        (DynamicValue::Null, DynamicValue::Null) => true,
+        (DynamicValue::Union(disc_a, case_a, inner_a), DynamicValue::Union(disc_b, case_b, inner_b)) => {
+            // Discriminator + case name must match. The case name doubles
+            // as a guard against the encoder picking a different branch
+            // with the same discriminator value (would be a wire-level
+            // mismatch even if both values had the same underlying type).
+            disc_a == disc_b && case_a == case_b && compare_values(inner_a, inner_b)
+        }
+        (DynamicValue::Struct(ax), DynamicValue::Struct(bx)) => {
+            // Per-key compare for all keys present in ax. Keys present in bx
+            // but absent from ax are acceptable only when their value equals
+            // the type default (zero / false / empty): this covers mutable
+            // struct evolution where the wire omits trailing members that the
+            // local type descriptor carries with default values.
+            for (k, av) in ax {
+                match bx.get(k) {
+                    Some(bv) => {
+                        if !compare_values(av, bv) {
+                            return false;
+                        }
+                    }
+                    None => return false,
+                }
+            }
+            for (k, bv) in bx {
+                if !ax.contains_key(k) && !is_default_value(bv) {
+                    return false;
+                }
+            }
+            true
+        }
+        (DynamicValue::Sequence(ax), DynamicValue::Sequence(bx))
+        | (DynamicValue::Array(ax), DynamicValue::Array(bx)) => {
+            ax.len() == bx.len() && ax.iter().zip(bx.iter()).all(|(a, b)| compare_values(a, b))
+        }
+        // Cross-variant comparisons (e.g. Sequence vs Array) intentionally
+        // return false: they would mean a CDR-level mismatch even if the
+        // payload bytes look similar.
+        _ => false,
+    }
+}
+
+/// Returns `true` when `v` equals the DDS type default for its variant.
+///
+/// Used by `compare_dynamic_data` to accept struct fields that are absent
+/// from a decoded mutable payload (the wire omits trailing or unknown members)
+/// but present in the expected data with their default value. A non-default
+/// absent field means the expected sample genuinely differs from what arrived.
+fn is_default_value(v: &DynamicValue) -> bool {
+    match v {
+        DynamicValue::Bool(x) => !x,
+        DynamicValue::U8(x) => *x == 0,
+        DynamicValue::U16(x) => *x == 0,
+        DynamicValue::U32(x) => *x == 0,
+        DynamicValue::U64(x) => *x == 0,
+        DynamicValue::I8(x) => *x == 0,
+        DynamicValue::I16(x) => *x == 0,
+        DynamicValue::I32(x) => *x == 0,
+        DynamicValue::I64(x) => *x == 0,
+        DynamicValue::F32(x) => x.to_bits() == 0,
+        DynamicValue::F64(x) => x.to_bits() == 0,
+        DynamicValue::LongDouble(b) => b.iter().all(|&x| x == 0),
+        DynamicValue::Char(c) => *c == '\0',
+        DynamicValue::String(s) => s.is_empty(),
+        DynamicValue::WString(s) => s.is_empty(),
+        DynamicValue::Sequence(v) => v.is_empty(),
+        DynamicValue::Array(v) => v.iter().all(is_default_value),
+        DynamicValue::Struct(m) => m.values().all(is_default_value),
+        DynamicValue::Enum(n, _) => *n == 0,
+        DynamicValue::Union(..) | DynamicValue::Null => true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IEEE 754 binary128 (float128) helpers
+// ---------------------------------------------------------------------------
+// OMG IDL float128 serializes as IEEE 754 binary128 (1 sign + 15 exponent,
+// bias 16383 + 112 mantissa bits). Reference vendors (Cyclone measured on the
+// wire) emit true binary128 in CDR. Rust has no stable f128, so the driver
+// stores the 16 LE bytes and converts to/from f64 at the edges (XML literal
+// parse, display, semantic compare).
+
+/// Convert an f64 to IEEE binary128 little-endian bytes.
+pub fn f64_to_binary128_le(v: f64) -> [u8; 16] {
+    let bits = v.to_bits();
+    let sign = (bits >> 63) & 1;
+    let e = ((bits >> 52) & 0x7FF) as i64;
+    let m = bits & 0x000F_FFFF_FFFF_FFFF;
+
+    let (eq, mq): (u64, u128) = if e == 0x7FF {
+        // Inf / NaN: max exponent, shift the mantissa into the top bits.
+        (0x7FFF, (m as u128) << 60)
+    } else if e == 0 {
+        if m == 0 {
+            (0, 0) // signed zero
+        } else {
+            // f64 subnormal: normalize into a binary128 normal.
+            // value = m * 2^-1074; leading bit of m becomes implicit.
+            let lz = m.leading_zeros() as i64 - 11; // zeros within the 53-bit field
+            let shift = lz + 1;
+            let mant = (m << shift) & 0x000F_FFFF_FFFF_FFFF;
+            let e_unb = -1022 - shift;
+            (((e_unb + 16383) as u64), (mant as u128) << 60)
+        }
+    } else {
+        (((e - 1023 + 16383) as u64), (m as u128) << 60)
+    };
+
+    let raw: u128 = ((sign as u128) << 127) | ((eq as u128) << 112) | mq;
+    raw.to_le_bytes()
+}
+
+/// Convert IEEE binary128 little-endian bytes to the nearest f64.
+///
+/// Legacy tolerance: a pre-spec HDDS peer stored the f64 bits in the first 8
+/// bytes with a zero tail; that layout has an all-zero exponent field at
+/// bytes 14..16 while carrying non-zero data below, which no binary128 value
+/// produced by the suite does (subnormal quads are out of the suite's value
+/// range) - detect it and read the f64 directly.
+pub fn binary128_le_to_f64(bytes: &[u8; 16]) -> f64 {
+    let raw = u128::from_le_bytes(*bytes);
+    let sign = ((raw >> 127) & 1) as u64;
+    let eq = ((raw >> 112) & 0x7FFF) as i64;
+    let mq = raw & ((1u128 << 112) - 1);
+
+    if eq == 0 && mq != 0 {
+        // Not a suite-range binary128 (would be subnormal ~1e-4932):
+        // interpret as the legacy f64-in-16 layout.
+        let mut f64_bits = [0u8; 8];
+        f64_bits.copy_from_slice(&bytes[..8]);
+        return f64::from_le_bytes(f64_bits);
+    }
+
+    if eq == 0x7FFF {
+        let m52 = (mq >> 60) as u64;
+        let bits = (sign << 63) | (0x7FFu64 << 52) | m52;
+        return f64::from_bits(bits);
+    }
+    if eq == 0 {
+        return if sign == 1 { -0.0 } else { 0.0 };
+    }
+
+    let e_unb = eq - 16383;
+    let e64 = e_unb + 1023;
+    if e64 >= 0x7FF {
+        return if sign == 1 {
+            f64::NEG_INFINITY
+        } else {
+            f64::INFINITY
+        };
+    }
+    if e64 <= 0 {
+        // Underflows f64 normals; suite values never do. Flush to zero.
+        return if sign == 1 { -0.0 } else { 0.0 };
+    }
+
+    // Round to nearest on the 52-bit truncation (guard bit at position 59).
+    let mut m52 = (mq >> 60) as u64;
+    let mut e_out = e64 as u64;
+    if (mq >> 59) & 1 == 1 {
+        m52 += 1;
+        if m52 == (1 << 52) {
+            m52 = 0;
+            e_out += 1;
+        }
+    }
+    f64::from_bits((sign << 63) | (e_out << 52) | m52)
+}
+
+/// Convert an unsigned 128-bit integer VALUE to IEEE binary128 LE bytes
+/// (round-to-nearest-even when the value needs more than 113 significand
+/// bits). Used for the camp-B reading of ambiguous 32-hex float128 literals:
+/// some vendors (coredx, cyclone) parse the literal as an integer and convert
+/// it numerically instead of taking it as the raw bit pattern. Suite literals
+/// are far below 2^113, so the conversion is exact there.
+pub fn u128_to_binary128_le(v: u128) -> [u8; 16] {
+    if v == 0 {
+        return [0u8; 16];
+    }
+    let bl = 128 - v.leading_zeros(); // significant bits, 1..=128
+    let mut exp_field = (bl as u128 - 1) + 16383;
+    let frac: u128 = if bl <= 113 {
+        // Exact: drop the implicit leading 1, left-align into 112 bits.
+        (v << (113 - bl)) & ((1u128 << 112) - 1)
+    } else {
+        // Round the top 113 bits nearest-even on guard + sticky.
+        let shift = bl - 113;
+        let mut top = v >> shift; // 113 bits incl. implicit leading 1
+        let guard = (v >> (shift - 1)) & 1 == 1;
+        let sticky = v & ((1u128 << (shift - 1)) - 1) != 0;
+        if guard && (sticky || top & 1 == 1) {
+            top += 1;
+            if top >> 113 == 1 {
+                top >>= 1;
+                exp_field += 1;
+            }
+        }
+        top & ((1u128 << 112) - 1)
+    };
+    ((exp_field << 112) | frac).to_le_bytes()
+}
+
+// ---------------------------------------------------------------------------
+// Exact decimal literal -> x87-extended-precision binary128
+// ---------------------------------------------------------------------------
+// Reference vendors (coredx, connext measured on the wire) parse float128
+// XML literals with strtold: x87 80-bit extended precision, i.e. the
+// significand is rounded to 64 bits (round-to-nearest-even) and then widened
+// to binary128 with a zero tail (compiler __extendxftf2). Parsing with f64
+// (53-bit significand) loses the low 11 mantissa bits and produces different
+// wire bytes, which vendor subscribers memcmp-reject (DATA_NOT_CORRECT).
+//
+// This converter parses the decimal literal EXACTLY using a small bignum,
+// rounds the significand to 64 bits nearest-even, and widens to binary128.
+// For every finite literal this is byte-identical to strtold + widening.
+// Integer-valued and dyadic literals that fit 53 bits are exact in both f64
+// and x87, so their bytes are unchanged from the previous f64 path.
+
+/// Number of significand bits of x87 double-extended precision.
+const X87_SIG_BITS: u32 = 64;
+
+/// Minimal little-endian-limb bignum. Sized for the OMG suite literals
+/// (short decimal strings); hard caps in the caller keep it bounded.
+struct Big(Vec<u64>);
+
+impl Big {
+    fn from_decimal_digits(digits: &[u8]) -> Big {
+        let mut n = Big(vec![0]);
+        for &d in digits {
+            n.mul_small(10);
+            n.add_small(u64::from(d));
+        }
+        n
+    }
+
+    fn mul_small(&mut self, m: u64) {
+        let mut carry: u128 = 0;
+        for l in &mut self.0 {
+            let p = (*l as u128) * (m as u128) + carry;
+            *l = p as u64;
+            carry = p >> 64;
+        }
+        if carry != 0 {
+            self.0.push(carry as u64);
+        }
+    }
+
+    fn add_small(&mut self, a: u64) {
+        let mut carry = a;
+        for l in &mut self.0 {
+            let (s, c) = l.overflowing_add(carry);
+            *l = s;
+            carry = u64::from(c);
+            if carry == 0 {
+                return;
+            }
+        }
+        if carry != 0 {
+            self.0.push(carry);
+        }
+    }
+
+    /// Divide in place by a small divisor, returning the remainder.
+    fn div_small(&mut self, d: u64) -> u64 {
+        let mut rem: u128 = 0;
+        for l in self.0.iter_mut().rev() {
+            let cur = (rem << 64) | (*l as u128);
+            *l = (cur / (d as u128)) as u64;
+            rem = cur % (d as u128);
+        }
+        while self.0.len() > 1 && *self.0.last().expect("non-empty") == 0 {
+            self.0.pop();
+        }
+        rem as u64
+    }
+
+    /// Shift left by `bits`.
+    fn shl(&mut self, bits: u32) {
+        let limbs = (bits / 64) as usize;
+        let rem = bits % 64;
+        if rem != 0 {
+            let mut carry = 0u64;
+            for l in &mut self.0 {
+                let new_carry = *l >> (64 - rem);
+                *l = (*l << rem) | carry;
+                carry = new_carry;
+            }
+            if carry != 0 {
+                self.0.push(carry);
+            }
+        }
+        if limbs > 0 {
+            let mut v = vec![0u64; limbs];
+            v.extend_from_slice(&self.0);
+            self.0 = v;
+        }
+    }
+
+    /// Total significant bits (0 for zero).
+    fn bitlen(&self) -> u64 {
+        for (i, &l) in self.0.iter().enumerate().rev() {
+            if l != 0 {
+                return (i as u64) * 64 + (64 - u64::from(l.leading_zeros()));
+            }
+        }
+        0
+    }
+
+    fn bit(&self, i: u64) -> bool {
+        let limb = (i / 64) as usize;
+        if limb >= self.0.len() {
+            return false;
+        }
+        (self.0[limb] >> (i % 64)) & 1 == 1
+    }
+
+    /// True when any bit strictly below position `i` is set.
+    fn any_bit_below(&self, i: u64) -> bool {
+        let full = (i / 64) as usize;
+        let rem = i % 64;
+        for (idx, &l) in self.0.iter().enumerate() {
+            if idx < full {
+                if l != 0 {
+                    return true;
+                }
+            } else if idx == full {
+                return rem != 0 && (l & ((1u64 << rem) - 1)) != 0;
+            } else {
+                break;
+            }
+        }
+        false
+    }
+
+    /// Top `n` bits as an integer (requires bitlen() >= n).
+    fn top_bits(&self, n: u32) -> u64 {
+        let bl = self.bitlen();
+        debug_assert!(bl >= u64::from(n));
+        let shift = bl - u64::from(n);
+        let mut out: u64 = 0;
+        for k in 0..u64::from(n) {
+            out = (out << 1) | u64::from(self.bit(bl - 1 - k));
+        }
+        debug_assert!(shift == 0 || out >> (n - 1) == 1);
+        out
+    }
+}
+
+/// Parse a decimal float literal exactly and produce IEEE binary128 LE bytes
+/// carrying the value rounded to a 64-bit significand (x87 extended,
+/// round-to-nearest-even) -- byte-identical to what strtold-based vendors
+/// put on the wire. Returns None for anything that is not a plain finite
+/// decimal literal (inf/nan/hex/garbage/out-of-range): callers fall back.
+pub fn decimal_to_binary128_x87_le(s: &str) -> Option<[u8; 16]> {
+    let s = s.trim();
+    let (neg, rest) = match s.as_bytes().first()? {
+        b'-' => (true, &s[1..]),
+        b'+' => (false, &s[1..]),
+        _ => (false, s),
+    };
+
+    // Split off an optional exponent part.
+    let (mant, exp10) = match rest.find(['e', 'E']) {
+        Some(pos) => {
+            let e: i64 = rest[pos + 1..].parse().ok()?;
+            (&rest[..pos], e)
+        }
+        None => (rest, 0i64),
+    };
+
+    // Mantissa: digits with at most one '.'.
+    let mut digits: Vec<u8> = Vec::new();
+    let mut frac_len: i64 = 0;
+    let mut seen_dot = false;
+    let mut seen_digit = false;
+    for c in mant.bytes() {
+        match c {
+            b'0'..=b'9' => {
+                seen_digit = true;
+                // Skip leading zeros (they carry no value).
+                if !(digits.is_empty() && c == b'0') {
+                    digits.push(c - b'0');
+                }
+                if seen_dot {
+                    frac_len += 1;
+                }
+            }
+            b'.' if !seen_dot => seen_dot = true,
+            _ => return None,
+        }
+    }
+    if !seen_digit {
+        return None;
+    }
+
+    // Bound the work (suite literals are tiny; these caps are generous).
+    if digits.len() > 768 {
+        return None;
+    }
+    let dec_exp = exp10.checked_sub(frac_len)?;
+    if !(-6000..=6000).contains(&dec_exp) {
+        return None;
+    }
+
+    if digits.iter().all(|&d| d == 0) {
+        // Signed zero.
+        let mut out = [0u8; 16];
+        if neg {
+            out[15] = 0x80;
+        }
+        return Some(out);
+    }
+
+    let mut n = Big::from_decimal_digits(&digits);
+    let mut sticky = false;
+    let e2: i64; // value = N * 2^e2 (+ sticky below the last bit of N)
+
+    if dec_exp >= 0 {
+        // Exact integer: N *= 10^dec_exp.
+        let mut left = dec_exp;
+        while left >= 19 {
+            n.mul_small(10u64.pow(19));
+            left -= 19;
+        }
+        if left > 0 {
+            n.mul_small(10u64.pow(left as u32));
+        }
+        e2 = 0;
+    } else {
+        // value = N / (2^f * 5^f). Pre-shift so the quotient keeps well
+        // over 64 significant bits, then divide by 5^f in u64-sized chunks
+        // (5^27 < 2^63). Any non-zero remainder folds into sticky.
+        let f = -dec_exp;
+        let t = 3 * f + 128; // 5^f < 2^(2.33*f): quotient bitlen > 64
+        n.shl(u32::try_from(t).ok()?);
+        let mut left = f;
+        while left >= 27 {
+            sticky |= n.div_small(5u64.pow(27)) != 0;
+            left -= 27;
+        }
+        if left > 0 {
+            sticky |= n.div_small(5u64.pow(left as u32)) != 0;
+        }
+        e2 = -(t + f);
+    }
+
+    // Round the significand to X87_SIG_BITS bits, nearest-even.
+    let bl = n.bitlen();
+    debug_assert!(bl > 0);
+    let mut e_unb = i64::try_from(bl).ok()? - 1 + e2;
+    let mut m: u64;
+    if bl <= u64::from(X87_SIG_BITS) {
+        m = n.top_bits(u32::try_from(bl).ok()?) << (u64::from(X87_SIG_BITS) - bl);
+        // Exact: no guard/sticky from N itself. sticky can only be set on
+        // the division path, whose quotient always exceeds 64 bits.
+        debug_assert!(!sticky);
+    } else {
+        let shift = bl - u64::from(X87_SIG_BITS);
+        m = n.top_bits(X87_SIG_BITS);
+        let guard = n.bit(shift - 1);
+        sticky |= n.any_bit_below(shift - 1);
+        if guard && (sticky || (m & 1) == 1) {
+            let (sum, overflow) = m.overflowing_add(1);
+            m = sum;
+            if overflow {
+                m = 1u64 << 63;
+                e_unb += 1;
+            }
+        }
+    }
+    debug_assert!(m >> 63 == 1);
+
+    // Widen the 64-bit significand to binary128 (1 implicit + 112 fraction).
+    let exp_field = e_unb + 16383;
+    if !(1..=0x7FFE).contains(&exp_field) {
+        return None; // out of suite range; caller falls back
+    }
+    let frac63 = u128::from(m & ((1u64 << 63) - 1));
+    let raw: u128 =
+        (u128::from(neg) << 127) | ((exp_field as u128) << 112) | (frac63 << 49);
+    Some(raw.to_le_bytes())
+}
+
+// ---------------------------------------------------------------------------
+// Ambiguous 32-hex float128 literals: RX-side dual acceptance
+// ---------------------------------------------------------------------------
+// The OMG corpus writes float128 payloads as 0x + 32 hex chars (e.g.
+// struct_float128_x1.xml: 0x0000000000000000000000003f800000). Vendors split
+// into two camps on what that means:
+//   camp A (HDDS, connext): the raw binary128 bit pattern, byte for byte;
+//   camp B (coredx, cyclone): the hex INTEGER value (0x3f800000 = 1065353216)
+//     converted numerically to binary128.
+// TX keeps emitting the camp-A form (no per-peer gaming). On RX, a received
+// long double is accepted when it matches EITHER reading of the literal.
+// Alternates are registered only at 32-hex literal parse time, so decimal
+// literals and wire-decoded values never gain aliases.
+
+/// (camp-A raw literal bytes, camp-B integer-value bytes) pairs registered by
+/// the literal parser. The corpus holds a handful at most; linear scan is fine.
+static F128_HEX_ALTERNATES: Mutex<Vec<([u8; 16], [u8; 16])>> = Mutex::new(Vec::new());
+
+/// Record the camp-B alternate reading for a 32-hex float128 literal.
+fn register_f128_hex_alternate(raw: [u8; 16], alt: [u8; 16]) {
+    let mut reg = F128_HEX_ALTERNATES
+        .lock()
+        .expect("f128 alternate registry poisoned");
+    if !reg.iter().any(|(r, a)| *r == raw && *a == alt) {
+        reg.push((raw, alt));
+    }
+}
+
+/// Base float128 equality: byte-identical, or equal after conversion to
+/// f64 within a small relative tolerance (covers the precision difference
+/// between a text literal parsed to f64 by HDDS and to x87/quad by a vendor).
+fn long_double_base_equal(a: &[u8; 16], b: &[u8; 16]) -> bool {
+    if a[..] == b[..] {
+        return true;
+    }
+    let fa = binary128_le_to_f64(a);
+    let fb = binary128_le_to_f64(b);
+    if fa == fb {
+        return true;
+    }
+    let tol = 1e-9_f64 * fa.abs().max(fb.abs()).max(1.0);
+    (fa - fb).abs() <= tol
+}
+
+/// Semantic float128 equality: base equality, or a match against the camp-B
+/// alternate of a 32-hex literal (either argument order: the compare is
+/// symmetric and does not know which side is the expected sample).
+fn long_double_semantically_equal(a: &[u8; 16], b: &[u8; 16]) -> bool {
+    if long_double_base_equal(a, b) {
+        return true;
+    }
+    let reg = F128_HEX_ALTERNATES
+        .lock()
+        .expect("f128 alternate registry poisoned");
+    reg.iter().any(|(raw, alt)| {
+        (raw == a && long_double_base_equal(alt, b))
+            || (raw == b && long_double_base_equal(alt, a))
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Internal parser
+// ---------------------------------------------------------------------------
+
+fn parse_data_xml(
+    xml: &str,
+    type_desc: &Arc<TypeDescriptor>,
+) -> Result<DynamicData, String> {
+    // Find the root element regardless of its tag name.
+    let tree = parse_xml_to_tree(xml)?;
+    let value = build_value_from_node(&tree, &type_desc.kind)?;
+    DynamicData::from_value(type_desc, value).map_err(|e| format!("DynamicData error: {}", e))
+}
+
+// ---------------------------------------------------------------------------
+// Generic XML tree
+// ---------------------------------------------------------------------------
+
+/// A minimal XML tree node: name + text content + children. Attributes are
+/// captured but unused in the OMG data corpus.
+#[derive(Debug, Default)]
+struct XmlNode {
+    name: String,
+    text: String,
+    children: Vec<XmlNode>,
+}
+
+impl XmlNode {
+    fn child(&self, name: &str) -> Option<&XmlNode> {
+        self.children.iter().find(|c| c.name == name)
+    }
+
+    /// Return all direct children whose tag equals `name`.
+    fn children_named(&self, name: &str) -> Vec<&XmlNode> {
+        self.children.iter().filter(|c| c.name == name).collect()
+    }
+}
+
+/// Parse an XML string into a single root XmlNode. The OMG data corpus
+/// always wraps the payload in a single root element (e.g. `<struct>`,
+/// `<union_1>`); if more than one root element is found, the first is used
+/// and a warning is logged.
+fn parse_xml_to_tree(xml: &str) -> Result<XmlNode, String> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut buf = Vec::new();
+    let mut stack: Vec<XmlNode> = Vec::new();
+    let mut root: Option<XmlNode> = None;
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) => {
+                let n = bytes_start_to_node(e);
+                stack.push(n);
+            }
+            Ok(Event::Empty(ref e)) => {
+                let n = bytes_start_to_node(e);
+                if let Some(parent) = stack.last_mut() {
+                    parent.children.push(n);
+                } else {
+                    root = Some(n);
+                }
+            }
+            Ok(Event::Text(ref e)) => {
+                let text = e.unescape().unwrap_or_default().to_string();
+                let trimmed = text.trim();
+                if !trimmed.is_empty() {
+                    if let Some(top) = stack.last_mut() {
+                        if top.text.is_empty() {
+                            top.text = trimmed.to_string();
+                        } else {
+                            top.text.push(' ');
+                            top.text.push_str(trimmed);
+                        }
+                    }
+                }
+            }
+            Ok(Event::End(_)) => {
+                if let Some(node) = stack.pop() {
+                    if let Some(parent) = stack.last_mut() {
+                        parent.children.push(node);
+                    } else if root.is_none() {
+                        root = Some(node);
+                    }
+                    // If we already saw a root, the additional top-level
+                    // element is silently appended as a sibling of the
+                    // first root via the parent path above (not reachable
+                    // here since stack is empty).
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(format!("XML parse error: {}", e)),
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    root.ok_or_else(|| "empty XML document".to_string())
+}
+
+fn bytes_start_to_node(e: &BytesStart) -> XmlNode {
+    let name = std::str::from_utf8(e.name().as_ref())
+        .unwrap_or("")
+        .to_string();
+    XmlNode {
+        name,
+        text: String::new(),
+        children: Vec::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Recursive type-driven construction
+// ---------------------------------------------------------------------------
+
+fn build_value_from_node(node: &XmlNode, kind: &TypeKind) -> Result<DynamicValue, String> {
+    match kind {
+        TypeKind::Primitive(pk) => parse_primitive_strict(node.text.trim(), *pk),
+        TypeKind::Enum(e) => parse_enum_strict(node.text.trim(), e),
+        TypeKind::Struct(fields) => {
+            let mut map: HashMap<String, DynamicValue> = HashMap::new();
+            // Default everything up front so missing fields stay
+            // deterministic. The OMG corpus often omits fields a publisher
+            // type does not carry (e.g. struct_a2 publishing data shaped
+            // for struct_a3).
+            for f in fields {
+                map.insert(f.name.clone(), default_value(&f.type_desc.kind));
+            }
+            for f in fields {
+                if let Some(child) = node.child(&f.name) {
+                    let val = build_value_from_node(child, &f.type_desc.kind)?;
+                    map.insert(f.name.clone(), val);
+                }
+            }
+            Ok(DynamicValue::Struct(map))
+        }
+        TypeKind::Sequence(seq) => build_sequence(node, &seq.element_type.kind, false),
+        TypeKind::Array(arr) => {
+            let v = build_sequence(node, &arr.element_type.kind, true)?;
+            match v {
+                DynamicValue::Sequence(items) | DynamicValue::Array(items) => {
+                    // Pad with default values if the XML provided fewer
+                    // items than the declared array length. Strict mode
+                    // would error here; the OMG corpus has well-formed
+                    // arrays so the pad is only a safety net.
+                    let mut items = items;
+                    while items.len() < arr.length {
+                        items.push(default_value(&arr.element_type.kind));
+                    }
+                    if items.len() > arr.length {
+                        return Err(format!(
+                            "array overflow: declared {}, got {}",
+                            arr.length,
+                            items.len()
+                        ));
+                    }
+                    Ok(DynamicValue::Array(items))
+                }
+                _ => unreachable!(),
+            }
+        }
+        TypeKind::Union(u) => build_union(node, u),
+        TypeKind::Nested(inner) => build_value_from_node(node, &inner.kind),
+    }
+}
+
+fn build_sequence(
+    node: &XmlNode,
+    element_kind: &TypeKind,
+    is_array: bool,
+) -> Result<DynamicValue, String> {
+    let mut items: Vec<DynamicValue> = Vec::new();
+    let item_nodes = node.children_named("item");
+
+    if item_nodes.is_empty() && !node.text.trim().is_empty() {
+        // Allow a single inline scalar like `<x>3</x>` to behave as a
+        // 1-element sequence, mirroring how some OMG samples express
+        // optional/singleton lists.
+        items.push(parse_node_as_scalar(node, element_kind)?);
+    } else {
+        for item in item_nodes {
+            // For struct elements, the `<item>` wraps the struct body
+            // directly. For scalars, the `<item>` carries text content.
+            // Decide based on the kind, not on the XML shape.
+            match element_kind {
+                TypeKind::Primitive(_) | TypeKind::Enum(_) => {
+                    items.push(parse_node_as_scalar(item, element_kind)?);
+                }
+                _ => {
+                    items.push(build_value_from_node(item, element_kind)?);
+                }
+            }
+        }
+    }
+
+    if is_array {
+        Ok(DynamicValue::Array(items))
+    } else {
+        Ok(DynamicValue::Sequence(items))
+    }
+}
+
+fn build_union(
+    node: &XmlNode,
+    union: &hdds::dynamic::UnionDescriptor,
+) -> Result<DynamicValue, String> {
+    // Read the discriminator. The OMG corpus uses a `<discriminator>` child
+    // node carrying a numeric literal (decimal or 0x-prefixed hex).
+    //
+    // Some OMG test data files use the same XML as the equivalent struct type
+    // (e.g. array_num_20.xml is used for both the struct and union variants of
+    // a sequence-bearing type). In that case the root element is named `struct`
+    // and there is no `<discriminator>` child. Fall back to discriminator
+    // inference: scan the union's cases and pick the first case whose member
+    // name matches a child element of the node. Use the first label of that
+    // case as the discriminator value. This correctly handles single-case
+    // unions (the dominant pattern in the tryconstruct/sequence corpus).
+    let (disc, case) = if let Some(disc_node) = node.child("discriminator") {
+        let disc = parse_int_literal_strict(disc_node.text.trim()).map_err(|e| {
+            format!(
+                "union '{}': discriminator '{}' is not an integer: {}",
+                node.name, disc_node.text, e
+            )
+        })?;
+        let case = union
+            .case_by_discriminator(disc)
+            .ok_or_else(|| format!("union '{}': no case for discriminator {}", node.name, disc))?;
+        (disc, case)
+    } else {
+        // No explicit discriminator: infer from child element names.
+        let inferred = union
+            .cases
+            .iter()
+            .find(|c| node.child(&c.name).is_some())
+            .map(|c| {
+                let disc = c.labels.first().copied().unwrap_or(0);
+                (disc, c)
+            });
+        match inferred {
+            Some((disc, case)) => (disc, case),
+            None => {
+                // No matching child found; use the first case with discriminator 1
+                // (common for single-case unions whose data was written as a struct).
+                let case = union
+                    .case_by_discriminator(1)
+                    .or_else(|| union.cases.first())
+                    .ok_or_else(|| {
+                        format!(
+                            "union '{}': no <discriminator> and no matchable case member; \
+                             union has {} cases",
+                            node.name,
+                            union.cases.len()
+                        )
+                    })?;
+                let disc = case.labels.first().copied().unwrap_or(1);
+                (disc, case)
+            }
+        }
+    };
+
+    // Look for a child element carrying the case payload. We accept either
+    // a child element whose tag matches the case name (preferred), or fall
+    // back to a generic `<value>` element for vendors that prefer that
+    // shape.
+    let payload_node = node
+        .child(&case.name)
+        .or_else(|| node.child("value"));
+
+    let inner = match payload_node {
+        Some(child) => build_value_from_node(child, &case.type_desc.kind)?,
+        None => default_value(&case.type_desc.kind),
+    };
+
+    Ok(DynamicValue::Union(disc, case.name.clone(), Box::new(inner)))
+}
+
+fn parse_node_as_scalar(node: &XmlNode, kind: &TypeKind) -> Result<DynamicValue, String> {
+    let t = node.text.trim();
+    match kind {
+        TypeKind::Primitive(pk) => parse_primitive_strict(t, *pk),
+        TypeKind::Enum(e) => parse_enum_strict(t, e),
+        TypeKind::Nested(inner) => parse_node_as_scalar(node, &inner.kind),
+        _ => Err(format!(
+            "expected scalar/enum at <{}>, got nested kind {:?}",
+            node.name, kind
+        )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Strict primitive / enum parsing
+// ---------------------------------------------------------------------------
+
+fn parse_int_literal_strict(s: &str) -> Result<i64, String> {
+    let s = s.trim();
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        i64::from_str_radix(hex, 16).map_err(|e| e.to_string())
+    } else {
+        s.parse::<i64>().map_err(|e| e.to_string())
+    }
+}
+
+fn parse_primitive_strict(t: &str, pk: PrimitiveKind) -> Result<DynamicValue, String> {
+    let parsed = match pk {
+        PrimitiveKind::Bool => match t.to_lowercase().as_str() {
+            "true" | "1" => Ok(DynamicValue::Bool(true)),
+            "false" | "0" => Ok(DynamicValue::Bool(false)),
+            _ => Err(format!("bad bool literal '{}'", t)),
+        },
+        // Allow hex literals on every integer type. Byte shares u8 storage.
+        PrimitiveKind::U8 | PrimitiveKind::Byte => parse_int_literal_strict(t)
+            .and_then(|v| u8::try_from(v).map_err(|e| e.to_string()))
+            .map(DynamicValue::U8),
+        PrimitiveKind::U16 => parse_int_literal_strict(t)
+            .and_then(|v| u16::try_from(v).map_err(|e| e.to_string()))
+            .map(DynamicValue::U16),
+        PrimitiveKind::U32 => parse_int_literal_strict(t)
+            .and_then(|v| u32::try_from(v).map_err(|e| e.to_string()))
+            .map(DynamicValue::U32),
+        PrimitiveKind::U64 => {
+            // u64 cannot be represented in i64 for the top range, so accept
+            // either form here.
+            let s = t.trim();
+            let r = if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+                u64::from_str_radix(hex, 16).map_err(|e| e.to_string())
+            } else {
+                s.parse::<u64>().map_err(|e| e.to_string())
+            };
+            r.map(DynamicValue::U64)
+        }
+        PrimitiveKind::I8 => parse_int_literal_strict(t)
+            .and_then(|v| i8::try_from(v).map_err(|e| e.to_string()))
+            .map(DynamicValue::I8),
+        PrimitiveKind::I16 => parse_int_literal_strict(t)
+            .and_then(|v| i16::try_from(v).map_err(|e| e.to_string()))
+            .map(DynamicValue::I16),
+        PrimitiveKind::I32 => parse_int_literal_strict(t)
+            .and_then(|v| i32::try_from(v).map_err(|e| e.to_string()))
+            .map(DynamicValue::I32),
+        PrimitiveKind::I64 => parse_int_literal_strict(t).map(DynamicValue::I64),
+        PrimitiveKind::F32 => t.parse::<f32>().map(DynamicValue::F32).map_err(|e| e.to_string()),
+        PrimitiveKind::F64 => t.parse::<f64>().map(DynamicValue::F64).map_err(|e| e.to_string()),
+        PrimitiveKind::LongDouble => {
+            // OMG harness encodes float128 as a 0x-prefixed 32-hex-char string
+            // (16 raw bytes, big-endian as written). When the literal has exactly
+            // 32 hex digits after the 0x prefix, decode directly into the 16-byte
+            // storage array so that byte-for-byte round-trip works between pub and sub.
+            // Fall back to f64 decimal parse for any other format.
+            let mut bytes = [0u8; hdds::dynamic::LONG_DOUBLE_SIZE];
+            if let Some(hex) = t.strip_prefix("0x").or_else(|| t.strip_prefix("0X")) {
+                if hex.len() == 32 {
+                    for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+                        let hi = (chunk[0] as char).to_digit(16).ok_or("invalid hex digit")?;
+                        let lo = (chunk[1] as char).to_digit(16).ok_or("invalid hex digit")?;
+                        bytes[i] = (hi as u8) << 4 | lo as u8;
+                    }
+                    // Ambiguity guard: camp-B vendors (coredx, cyclone) read
+                    // this literal as an integer VALUE and convert it to
+                    // binary128 numerically. Register that reading as an
+                    // RX-acceptable alternate; TX keeps the raw camp-A bytes.
+                    if let Ok(v) = u128::from_str_radix(hex, 16) {
+                        let alt = u128_to_binary128_le(v);
+                        if alt != bytes {
+                            register_f128_hex_alternate(bytes, alt);
+                        }
+                    }
+                    return Ok(DynamicValue::LongDouble(bytes));
+                }
+            }
+            // Decimal literal: reference vendors (coredx, connext) parse it
+            // with strtold (x87 80-bit, 64-bit significand) and widen to
+            // binary128 on the wire; their subscribers memcmp against that.
+            // Produce the same bytes via exact decimal parsing + 64-bit
+            // round-to-nearest-even. Fall back to the f64 path for anything
+            // the exact parser rejects (inf/nan/garbage: prior behavior).
+            if let Some(b) = decimal_to_binary128_x87_le(t) {
+                return Ok(DynamicValue::LongDouble(b));
+            }
+            let v = t.parse::<f64>().map_err(|e| e.to_string())?;
+            bytes = f64_to_binary128_le(v);
+            Ok(DynamicValue::LongDouble(bytes))
+        }
+        PrimitiveKind::Char => {
+            // OMG harness char8 literals are either a plain character or a
+            // 0x-prefixed code point (e.g. <x14>0x0e</x14>). Taking the first
+            // character of "0x0e" would yield '0' (0x30) - wrong data on the
+            // wire and a false compare against spec vendors.
+            let c = if (t.starts_with("0x") || t.starts_with("0X")) && t.len() > 2 {
+                u8::from_str_radix(&t[2..], 16)
+                    .map(|b| b as char)
+                    .map_err(|e| e.to_string())?
+            } else {
+                t.chars().next().unwrap_or('\0')
+            };
+            Ok(DynamicValue::Char(c))
+        }
+        PrimitiveKind::String { .. } => Ok(DynamicValue::String(t.to_string())),
+        PrimitiveKind::WString { .. } => Ok(DynamicValue::WString(t.to_string())),
+    };
+
+    // F-parse_scalar: any parse error becomes fatal so the test harness
+    // sees the diagnostic instead of "Received sample is different".
+    match parsed {
+        Ok(v) => Ok(v),
+        Err(e) => {
+            eprintln!(
+                "ERROR: cannot parse '{}' as {:?}: {}",
+                t, pk, e
+            );
+            std::process::exit(3);
+        }
+    }
+}
+
+fn parse_enum_strict(t: &str, e: &hdds::dynamic::EnumDescriptor) -> Result<DynamicValue, String> {
+    // Numeric first (the OMG corpus mostly uses bare integers, sometimes
+    // hex 0x prefixed).
+    if let Ok(n) = parse_int_literal_strict(t) {
+        let vname = e
+            .variants
+            .iter()
+            .find(|v| v.value == n)
+            .map(|v| v.name.clone())
+            .unwrap_or_else(|| n.to_string());
+        return Ok(DynamicValue::Enum(n, vname));
+    }
+    // Symbolic name.
+    if let Some(v) = e.variants.iter().find(|v| v.name == t) {
+        return Ok(DynamicValue::Enum(v.value, v.name.clone()));
+    }
+    eprintln!(
+        "ERROR: cannot parse '{}' as enum (no numeric match and no variant by name)",
+        t
+    );
+    std::process::exit(3);
+}
+
+fn default_value(kind: &TypeKind) -> DynamicValue {
+    match kind {
+        TypeKind::Primitive(pk) => match pk {
+            PrimitiveKind::Bool => DynamicValue::Bool(false),
+            PrimitiveKind::U8 | PrimitiveKind::Byte => DynamicValue::U8(0),
+            PrimitiveKind::U16 => DynamicValue::U16(0),
+            PrimitiveKind::U32 => DynamicValue::U32(0),
+            PrimitiveKind::U64 => DynamicValue::U64(0),
+            PrimitiveKind::I8 => DynamicValue::I8(0),
+            PrimitiveKind::I16 => DynamicValue::I16(0),
+            PrimitiveKind::I32 => DynamicValue::I32(0),
+            PrimitiveKind::I64 => DynamicValue::I64(0),
+            PrimitiveKind::F32 => DynamicValue::F32(0.0),
+            PrimitiveKind::F64 => DynamicValue::F64(0.0),
+            PrimitiveKind::LongDouble => {
+                DynamicValue::LongDouble([0u8; hdds::dynamic::LONG_DOUBLE_SIZE])
+            }
+            PrimitiveKind::Char => DynamicValue::Char('\0'),
+            PrimitiveKind::String { .. } => DynamicValue::String(String::new()),
+            PrimitiveKind::WString { .. } => DynamicValue::WString(String::new()),
+        },
+        TypeKind::Struct(fields) => {
+            let mut map = HashMap::new();
+            for f in fields {
+                map.insert(f.name.clone(), default_value(&f.type_desc.kind));
+            }
+            DynamicValue::Struct(map)
+        }
+        TypeKind::Sequence(_) => DynamicValue::Sequence(Vec::new()),
+        TypeKind::Array(a) => {
+            DynamicValue::Array(vec![default_value(&a.element_type.kind); a.length])
+        }
+        TypeKind::Enum(e) => {
+            let first = e.variants.first();
+            DynamicValue::Enum(
+                first.map(|v| v.value).unwrap_or(0),
+                first.map(|v| v.name.clone()).unwrap_or_default(),
+            )
+        }
+        TypeKind::Union(_) => DynamicValue::Null,
+        TypeKind::Nested(inner) => default_value(&inner.kind),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hdds::dynamic::{
+        EnumDescriptor, EnumVariant, FieldDescriptor, TypeDescriptor, UnionCase, UnionDescriptor,
+    };
+
+    fn td_i32() -> Arc<TypeDescriptor> {
+        Arc::new(TypeDescriptor::primitive("int32", PrimitiveKind::I32))
+    }
+
+    #[test]
+    fn parses_flat_struct() {
+        let td = Arc::new(TypeDescriptor::struct_type(
+            "S",
+            vec![
+                FieldDescriptor::new("x", td_i32()),
+                FieldDescriptor::new("y", td_i32()),
+            ],
+        ));
+        let xml = r#"<struct><x>1</x><y>2</y></struct>"#;
+        let dd = parse_data_xml(xml, &td).expect("parse");
+        match dd.value() {
+            DynamicValue::Struct(m) => {
+                assert!(matches!(m.get("x"), Some(DynamicValue::I32(1))));
+                assert!(matches!(m.get("y"), Some(DynamicValue::I32(2))));
+            }
+            v => panic!("expected struct, got {:?}", v),
+        }
+    }
+
+    #[test]
+    fn parses_nested_struct() {
+        let inner = Arc::new(TypeDescriptor::struct_type(
+            "Inner",
+            vec![FieldDescriptor::new("a", td_i32())],
+        ));
+        let outer = Arc::new(TypeDescriptor::struct_type(
+            "Outer",
+            vec![FieldDescriptor::new("inner", inner)],
+        ));
+        let xml = r#"<outer><inner><a>42</a></inner></outer>"#;
+        let dd = parse_data_xml(xml, &outer).expect("parse");
+        if let DynamicValue::Struct(m) = dd.value() {
+            if let Some(DynamicValue::Struct(im)) = m.get("inner") {
+                assert!(matches!(im.get("a"), Some(DynamicValue::I32(42))));
+                return;
+            }
+        }
+        panic!("expected nested struct");
+    }
+
+    #[test]
+    fn parses_sequence_of_struct() {
+        let item_td = Arc::new(TypeDescriptor::struct_type(
+            "Item",
+            vec![FieldDescriptor::new("x", td_i32())],
+        ));
+        let seq_td = Arc::new(TypeDescriptor::new(
+            "Seq",
+            TypeKind::Sequence(hdds::dynamic::SequenceDescriptor::unbounded(item_td)),
+        ));
+        let outer = Arc::new(TypeDescriptor::struct_type(
+            "Outer",
+            vec![FieldDescriptor::new("list", seq_td)],
+        ));
+        let xml = r#"<o><list><item><x>1</x></item><item><x>2</x></item></list></o>"#;
+        let dd = parse_data_xml(xml, &outer).expect("parse");
+        if let DynamicValue::Struct(m) = dd.value() {
+            if let Some(DynamicValue::Sequence(items)) = m.get("list") {
+                assert_eq!(items.len(), 2);
+                return;
+            }
+        }
+        panic!("expected sequence of struct");
+    }
+
+    #[test]
+    fn parses_union_with_discriminator_and_case() {
+        let disc = Arc::new(TypeDescriptor::primitive("uint8", PrimitiveKind::U8));
+        let cases = vec![UnionCase::single("x1", 1, td_i32())];
+        let td = Arc::new(TypeDescriptor::new(
+            "U",
+            TypeKind::Union(UnionDescriptor::new(disc, cases)),
+        ));
+        let xml = r#"<union_1><discriminator>0x01</discriminator><x1>123</x1></union_1>"#;
+        let dd = parse_data_xml(xml, &td).expect("parse");
+        match dd.value() {
+            DynamicValue::Union(d, case, inner) => {
+                assert_eq!(*d, 1);
+                assert_eq!(case, "x1");
+                assert!(matches!(**inner, DynamicValue::I32(123)));
+            }
+            v => panic!("expected Union, got {:?}", v),
+        }
+    }
+
+    #[test]
+    fn compare_unions_symmetrically() {
+        let a = DynamicValue::Union(1, "x".to_string(), Box::new(DynamicValue::I32(7)));
+        let b = DynamicValue::Union(1, "x".to_string(), Box::new(DynamicValue::I32(7)));
+        let c = DynamicValue::Union(2, "x".to_string(), Box::new(DynamicValue::I32(7)));
+        assert!(compare_values(&a, &b));
+        assert!(!compare_values(&a, &c));
+    }
+
+    #[test]
+    fn compare_structs_is_symmetric_on_keys() {
+        let mut a = HashMap::new();
+        a.insert("x".to_string(), DynamicValue::I32(1));
+        let mut b = a.clone();
+        b.insert("y".to_string(), DynamicValue::I32(2));
+        assert!(!compare_values(
+            &DynamicValue::Struct(a.clone()),
+            &DynamicValue::Struct(b.clone())
+        ));
+        assert!(!compare_values(
+            &DynamicValue::Struct(b),
+            &DynamicValue::Struct(a)
+        ));
+    }
+
+    #[test]
+    fn compare_long_double_is_semantic() {
+        let a = f64_to_binary128_le(12.3);
+        let b = f64_to_binary128_le(13.4);
+        assert!(!compare_values(
+            &DynamicValue::LongDouble(a),
+            &DynamicValue::LongDouble(b)
+        ));
+        assert!(compare_values(
+            &DynamicValue::LongDouble(a),
+            &DynamicValue::LongDouble(a)
+        ));
+    }
+
+    #[test]
+    fn binary128_roundtrip_and_vendor_bytes() {
+        for v in [0.0f64, 1.0, -1.0, 12.3, 10.1, -0.25, 1e300, 1e-300] {
+            let b = f64_to_binary128_le(v);
+            assert_eq!(binary128_le_to_f64(&b), v, "roundtrip {}", v);
+        }
+        // Cyclone 11.0.1 wire bytes for float128 12.3. NOTE: these are the
+        // f64-widened bytes (Cyclone parses the literal to double); the
+        // x87-sourced bytes coredx/connext emit differ in the low mantissa
+        // bits. Both must compare equal semantically to either source.
+        let cyclone_12_3: [u8; 16] = [
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xa0, 0x99, 0x99, 0x99, 0x99, 0x99, 0x89,
+            0x02, 0x40,
+        ];
+        let ours_f64 = f64_to_binary128_le(12.3);
+        assert_eq!(cyclone_12_3, ours_f64, "cyclone reference IS the f64-widened form");
+        let ours_x87 = decimal_to_binary128_x87_le("12.3").expect("parse 12.3");
+        assert!(long_double_semantically_equal(&cyclone_12_3, &ours_f64));
+        assert!(long_double_semantically_equal(&cyclone_12_3, &ours_x87));
+        assert!(long_double_semantically_equal(&ours_x87, &ours_f64));
+        // Legacy f64-in-16 layout must still be readable.
+        let mut legacy = [0u8; 16];
+        legacy[..8].copy_from_slice(&12.3f64.to_le_bytes());
+        assert_eq!(binary128_le_to_f64(&legacy), 12.3);
+    }
+
+    #[test]
+    fn parses_enum_by_value_or_name() {
+        let e = EnumDescriptor::new(vec![
+            EnumVariant::new("RED", 0),
+            EnumVariant::new("GREEN", 1),
+            EnumVariant::new("BLUE", 2),
+        ]);
+        let td = Arc::new(TypeDescriptor::new("Color", TypeKind::Enum(e.clone())));
+        let s = Arc::new(TypeDescriptor::struct_type(
+            "C",
+            vec![FieldDescriptor::new("c", td)],
+        ));
+        let xml = r#"<C><c>GREEN</c></C>"#;
+        let dd = parse_data_xml(xml, &s).expect("parse");
+        if let DynamicValue::Struct(m) = dd.value() {
+            assert!(matches!(m.get("c"), Some(DynamicValue::Enum(1, _))));
+        } else {
+            panic!()
+        }
+    }
+
+    // ========== float128 x87-extended decimal literal guards ================
+    //
+    // Ground truth generated two ways and cross-checked:
+    //  - coredx 12.3 wire bytes (frame 235, /tmp/waveE_cx_mut_x1.pcap)
+    //  - numpy.longdouble (x86 = x87 80-bit) widened to binary128:
+    //    strtold semantics = 64-bit significand round-to-nearest-even.
+
+    fn hexb(s: &str) -> [u8; 16] {
+        let mut out = [0u8; 16];
+        for i in 0..16 {
+            out[i] = u8::from_str_radix(&s[2 * i..2 * i + 2], 16).expect("hex");
+        }
+        out
+    }
+
+    #[test]
+    fn float128_decimal_literal_matches_x87_ground_truth() {
+        // (literal, binary128 LE bytes of strtold(literal) widened)
+        let cases: &[(&str, &str)] = &[
+            // The suite's only decimal float128 literal (struct_primitives.xml
+            // x12) -- coredx wire ground truth.
+            ("12.3", "0000000000009a999999999999890240"),
+            ("12.300000", "0000000000009a999999999999890240"),
+            ("-12.3", "0000000000009a9999999999998902c0"),
+            // Exponent forms must land on the same value.
+            ("1.23e1", "0000000000009a999999999999890240"),
+            ("123e-1", "0000000000009a999999999999890240"),
+            ("+12.3", "0000000000009a999999999999890240"),
+            // Other suite float literal values (x10/x11 shapes), as float128.
+            ("10.100000", "00000000000034333333333333430240"),
+            ("11.200000", "00000000000066666666666666660240"),
+            // Classic repeating-fraction and mixed cases.
+            ("0.1", "0000000000009a99999999999999fb3f"),
+            ("0.001", "00000000000076be9f1a2fdd2406f53f"),
+            ("1e-3", "00000000000076be9f1a2fdd2406f53f"),
+            ("123.456", "0000000000008c6ce7fba9f1d2ed0540"),
+            ("3.14159265358979323846", "0000000000006a84d14244b51f920040"),
+            ("2.718281828459045235360287", "00000000000036957645b1a8f05b0040"),
+            ("1000000.000001", "000000000000f4de1802000048e81240"),
+            ("1e30", "000000000000be9dce089a93e5936240"),
+        ];
+        for (lit, want) in cases {
+            let got = decimal_to_binary128_x87_le(lit)
+                .unwrap_or_else(|| panic!("parse '{}'", lit));
+            assert_eq!(got, hexb(want), "literal '{}'", lit);
+        }
+    }
+
+    #[test]
+    fn float128_integer_and_dyadic_literals_stay_f64_identical() {
+        // Values exact in <= 53 significand bits must produce byte-identical
+        // binary128 whether parsed via f64 (old path) or exactly (new path).
+        let cases: &[(&str, f64)] = &[
+            ("0", 0.0),
+            ("1", 1.0),
+            ("-1", -1.0),
+            ("5", 5.0),
+            ("13", 13.0),
+            ("100", 100.0),
+            ("13.000000", 13.0),
+            ("0.5", 0.5),
+            ("1.5", 1.5),
+            ("-0.25", -0.25),
+            ("-7.25", -7.25),
+            ("4294967296", 4294967296.0),
+        ];
+        for (lit, v) in cases {
+            let got = decimal_to_binary128_x87_le(lit)
+                .unwrap_or_else(|| panic!("parse '{}'", lit));
+            assert_eq!(
+                got,
+                f64_to_binary128_le(*v),
+                "literal '{}' must match the f64-widened bytes",
+                lit
+            );
+        }
+        // Signed zero keeps its sign bit.
+        let neg_zero = decimal_to_binary128_x87_le("-0.0").expect("parse -0.0");
+        assert_eq!(neg_zero, f64_to_binary128_le(-0.0));
+        assert_eq!(neg_zero[15], 0x80);
+    }
+
+    #[test]
+    fn float128_decimal_parser_rejects_non_decimal_input() {
+        for bad in ["", "-", "+", ".", "e5", "0x1p3", "nan", "inf", "-inf",
+                    "1.2.3", "12a", "1e", "1e999999", "1e-999999"] {
+            assert!(
+                decimal_to_binary128_x87_le(bad).is_none(),
+                "'{}' must be rejected (falls back to f64 path)",
+                bad
+            );
+        }
+    }
+
+    #[test]
+    fn float128_decimal_rx_tolerance_still_accepts_f64_sourced_peer() {
+        // A cyclone-style f64-sourced peer vs our new x87-sourced bytes must
+        // still compare equal through the RX tolerance path.
+        let x87 = decimal_to_binary128_x87_le("12.3").expect("parse");
+        let f64w = f64_to_binary128_le(12.3);
+        assert_ne!(x87, f64w, "the two sources differ in low mantissa bits");
+        assert!(compare_values(
+            &DynamicValue::LongDouble(x87),
+            &DynamicValue::LongDouble(f64w)
+        ));
+    }
+
+    // ========== ambiguous 32-hex float128 literal dual acceptance ===========
+    //
+    // struct_float128_x1.xml carries 0x0000000000000000000000003f800000.
+    // camp A (HDDS, connext) = raw binary128 bit pattern (subnormal ~0);
+    // camp B (coredx, cyclone) = integer 0x3f800000 = 1065353216 widened to
+    // binary128 (LE tail ... fc 1c 40, measured on the wire). RX must accept
+    // both; TX stays camp A.
+
+    #[test]
+    fn u128_to_binary128_matches_f64_widening_for_exact_ints() {
+        for v in [1u128, 2, 5, 127, 1_065_353_216, 4_294_967_296, 1u128 << 52] {
+            assert_eq!(
+                u128_to_binary128_le(v),
+                f64_to_binary128_le(v as f64),
+                "integer {} must widen identically via u128 and f64",
+                v
+            );
+        }
+        assert_eq!(u128_to_binary128_le(0), [0u8; 16]);
+        // 2^128 - 1 rounds up to 2^128: exponent field 16383 + 128 = 0x407f,
+        // zero fraction.
+        let mut want = [0u8; 16];
+        want[14] = 0x7f;
+        want[15] = 0x40;
+        assert_eq!(u128_to_binary128_le(u128::MAX), want);
+        // Round-half-even: 2^113 + 1 is exactly halfway, LSB even -> down.
+        assert_eq!(
+            u128_to_binary128_le((1u128 << 113) + 1),
+            u128_to_binary128_le(1u128 << 113)
+        );
+    }
+
+    #[test]
+    fn float128_32hex_literal_accepts_both_vendor_interpretations() {
+        let lit = "0x0000000000000000000000003f800000";
+        let parsed =
+            parse_primitive_strict(lit, PrimitiveKind::LongDouble).expect("parse 32-hex literal");
+        let camp_a = match parsed {
+            DynamicValue::LongDouble(b) => b,
+            other => panic!("expected LongDouble, got {:?}", other),
+        };
+        // TX/expected form unchanged: the raw literal bytes as written.
+        assert_eq!(camp_a, hexb("0000000000000000000000003f800000"));
+        // Camp B: 0x3f800000 = 1065353216 = 127 * 2^23 as binary128
+        // (wire-measured coredx/cyclone tail: .. fc 1c 40).
+        let camp_b = u128_to_binary128_le(0x3f80_0000);
+        assert_eq!(&camp_b[13..], &[0xfc, 0x1c, 0x40]);
+        assert!(camp_b[..13].iter().all(|&x| x == 0));
+        // RX accepts both readings, in both argument orders.
+        assert!(compare_values(
+            &DynamicValue::LongDouble(camp_a),
+            &DynamicValue::LongDouble(camp_a)
+        ));
+        assert!(compare_values(
+            &DynamicValue::LongDouble(camp_a),
+            &DynamicValue::LongDouble(camp_b)
+        ));
+        assert!(compare_values(
+            &DynamicValue::LongDouble(camp_b),
+            &DynamicValue::LongDouble(camp_a)
+        ));
+        // A third, unrelated value stays rejected against both forms.
+        let other = f64_to_binary128_le(42.0);
+        assert!(!compare_values(
+            &DynamicValue::LongDouble(camp_a),
+            &DynamicValue::LongDouble(other)
+        ));
+        assert!(!compare_values(
+            &DynamicValue::LongDouble(camp_b),
+            &DynamicValue::LongDouble(other)
+        ));
+    }
+
+    #[test]
+    fn float128_decimal_literal_gets_no_integer_alias() {
+        // Decimal literals must NOT gain an integer-reinterpretation alias:
+        // only 32-hex literals register a camp-B alternate.
+        let parsed =
+            parse_primitive_strict("12.3", PrimitiveKind::LongDouble).expect("parse decimal");
+        let bytes = match parsed {
+            DynamicValue::LongDouble(b) => b,
+            other => panic!("expected LongDouble, got {:?}", other),
+        };
+        let bogus = u128_to_binary128_le(u128::from_be_bytes(bytes));
+        assert_ne!(bogus, bytes);
+        assert!(!compare_values(
+            &DynamicValue::LongDouble(bytes),
+            &DynamicValue::LongDouble(bogus)
+        ));
+        assert!(!compare_values(
+            &DynamicValue::LongDouble(bogus),
+            &DynamicValue::LongDouble(bytes)
+        ));
+    }
+
+    // ========== ext_mutable_struct regression guards ========================
+    //
+    // Mutable struct evolution: a decoded struct (ax) may contain fewer fields
+    // than the expected struct (bx) when the wire type has fewer members. The
+    // missing fields in bx must equal their type default to pass.
+    // Locked by: data_loader.rs compare_values struct branch fix.
+
+    #[test]
+    fn compare_mutable_decoded_fewer_fields_than_expected_with_defaults_matches() {
+        // ax = decoded from wire (only x1 present, as from struct_m1)
+        // bx = expected loaded with struct_m2 type (x1=1, x2=0 default)
+        // Should match: bx["x2"] is I32(0) which is the type default.
+        let mut ax = HashMap::new();
+        ax.insert("x1".to_string(), DynamicValue::I32(1));
+
+        let mut bx = HashMap::new();
+        bx.insert("x1".to_string(), DynamicValue::I32(1));
+        bx.insert("x2".to_string(), DynamicValue::I32(0));
+
+        assert!(compare_values(
+            &DynamicValue::Struct(ax),
+            &DynamicValue::Struct(bx)
+        ));
+    }
+
+    #[test]
+    fn compare_mutable_decoded_fewer_fields_non_default_expected_does_not_match() {
+        // ax = decoded (x1=1 only), bx = expected with x2=99 (non-default)
+        // Should NOT match: x2 is absent from ax but non-default in bx.
+        let mut ax = HashMap::new();
+        ax.insert("x1".to_string(), DynamicValue::I32(1));
+
+        let mut bx = HashMap::new();
+        bx.insert("x1".to_string(), DynamicValue::I32(1));
+        bx.insert("x2".to_string(), DynamicValue::I32(99));
+
+        assert!(!compare_values(
+            &DynamicValue::Struct(ax),
+            &DynamicValue::Struct(bx)
+        ));
+    }
+
+    #[test]
+    fn compare_mutable_decoded_field_value_mismatch_fails() {
+        // Both have x1 but values differ.
+        let mut ax = HashMap::new();
+        ax.insert("x1".to_string(), DynamicValue::I32(5));
+
+        let mut bx = HashMap::new();
+        bx.insert("x1".to_string(), DynamicValue::I32(1));
+
+        assert!(!compare_values(
+            &DynamicValue::Struct(ax),
+            &DynamicValue::Struct(bx)
+        ));
+    }
+}

--- a/src/rs/HDDS/src/main.rs
+++ b/src/rs/HDDS/src/main.rs
@@ -1,0 +1,1342 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (c) 2025-2026 naskel.com
+
+//! HDDS OMG DDS-XTypes interoperability test application.
+//!
+//! Implements the OMG dds-xtypes interoperability test driver protocol:
+//!   - Publisher (-P): load type from XML, load data from XML, publish on loop
+//!   - Subscriber (-S): receive, decode with type from XML, compare to expected data
+//!
+//! Arg conventions match the OMG test_suite.py expectations:
+//!   -d <domain>  -t <topic>  -y <type_name>
+//!   --type-folder <dir>  --type-file <file>
+//!   --data-folder <dir>  --data-file <file>
+//!   -P / -S
+//!   -r <reliability>  -D <durability>  -x <xcdr_version>
+//!
+//! Behavior flags propagated by the OMG test_suite.py (each takes t/f/d for
+//! true / false / default - "default" leaves the implementation's native
+//! behavior in place):
+//!   --ignore-member-names <t|f|d>
+//!   --ignore-seq-bounds   <t|f|d>
+//!   --ignore-str-bounds   <t|f|d>
+//!   --prevent-type-widening <t|f|d>
+//!   --check-member-names  <t|f|d>
+//!   --check-seq-bounds    <t|f|d>
+//!   --check-str-bounds    <t|f|d>
+//!   --force-type-validation <t|f|d>
+//!   --disable-type-info       (bare flag)
+
+mod cdr_compat;
+mod data_loader;
+mod xml_loader;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use hdds::dynamic::{
+    decode_dynamic_with_version, encode_dynamic_with_version, type_descriptor_to_xtypes,
+    type_descriptor_to_xtypes_complete, DynamicData, Extensibility,
+};
+use hdds::CdrVersion;
+use hdds::dds::listener::{
+    DataReaderListener, DataWriterListener, InconsistentTopicStatus, PublicationMatchedStatus,
+    RequestedIncompatibleQosStatus, SubscriptionMatchedStatus,
+};
+use hdds::{DdsTrait, Participant, QoS, TransportMode, TypeConsistencyEnforcement};
+
+// ---------------------------------------------------------------------------
+// OMG harness listener strings (verbatim from interoperability_report.py)
+//
+// Publisher step 4 (pexpect.expect list):
+//   index 0: 'on_publication_matched()'      -> READER_MATCHED (success)
+//   index 1: 'on_offered_incompatible_qos'   -> INCOMPATIBLE_QOS  (no parens)
+//   index 2: 'on_inconsistent_topic'         -> INCONSISTENT_TOPIC
+//
+// Subscriber step 4 (pexpect.expect list):
+//   index 0: r'\[[0-9]+\]'                   -> success (sample or matched line)
+//   index 1: 'on_requested_incompatible_qos()' -> INCOMPATIBLE_QOS
+//   index 2: 'on_requested_deadline_missed()' -> DEADLINE_MISSED
+//   index 3: 'sample_received()'             -> success (handled by existing code)
+//   index 4: 'on_inconsistent_topic'         -> INCONSISTENT_TOPIC
+// ---------------------------------------------------------------------------
+
+/// Writer-side OMG listener: prints strings the harness regex matches on stdout.
+struct XtypesWriterListener;
+
+impl XtypesWriterListener {
+    fn new() -> Self {
+        XtypesWriterListener
+    }
+}
+
+impl<T: DdsTrait> DataWriterListener<T> for XtypesWriterListener {
+    // Called when a DataReader with compatible QoS is found.
+    // Harness pattern (pub step 4, index 0): 'on_publication_matched()'
+    fn on_publication_matched(&self, status: PublicationMatchedStatus) {
+        println!(
+            "on_publication_matched() current_count={}",
+            status.current_count
+        );
+    }
+
+    // Called when a DataReader with incompatible QoS is found.
+    // Harness pattern (pub step 4, index 1): 'on_offered_incompatible_qos'
+    // Note: the harness substring has no trailing '()' — the longer form still
+    // satisfies a substring match.
+    fn on_offered_incompatible_qos(&self, policy_id: u32, policy_name: &str) {
+        println!(
+            "on_offered_incompatible_qos() policy_id={} policy={}",
+            policy_id, policy_name
+        );
+    }
+
+    // Called when a remote DataReader on the same topic announces a type that
+    // is structurally incompatible with the local writer's type.
+    // Harness pattern (pub step 4, index 2): 'on_inconsistent_topic'
+    fn on_inconsistent_topic(&self, status: InconsistentTopicStatus) {
+        println!("on_inconsistent_topic total_count={}", status.total_count);
+    }
+}
+
+/// Reader-side OMG listener: prints strings the harness regex matches on stdout.
+struct XtypesReaderListener;
+
+impl XtypesReaderListener {
+    fn new() -> Self {
+        XtypesReaderListener
+    }
+}
+
+impl<T: DdsTrait> DataReaderListener<T> for XtypesReaderListener {
+    // Called when a DataWriter with compatible QoS is found.
+    // Harness does not key on 'on_subscription_matched()' for the success path
+    // (it keys on sample data '[N]'), but printing it aids debugging and may
+    // satisfy future harness versions that reference the DDS-RTPS spec string.
+    fn on_subscription_matched(&self, status: SubscriptionMatchedStatus) {
+        println!(
+            "on_subscription_matched() current_count={}",
+            status.current_count
+        );
+    }
+
+    // Called when a DataWriter with incompatible QoS is found.
+    // Harness pattern (sub step 4, index 1): 'on_requested_incompatible_qos()'
+    fn on_requested_incompatible_qos(&self, status: RequestedIncompatibleQosStatus) {
+        println!(
+            "on_requested_incompatible_qos() total_count={} last_policy_id={}",
+            status.total_count, status.last_policy_id
+        );
+    }
+
+    // Called when a remote DataWriter on the same topic announces a type that
+    // is structurally incompatible with the local reader's type.
+    // Harness pattern (sub step 4, index 4): 'on_inconsistent_topic'
+    fn on_inconsistent_topic(&self, status: InconsistentTopicStatus) {
+        println!("on_inconsistent_topic total_count={}", status.total_count);
+    }
+}
+
+use data_loader::{compare_dynamic_data, load_data_from_xml};
+use xml_loader::load_type_from_xml;
+
+// ---------------------------------------------------------------------------
+// Exit codes
+// ---------------------------------------------------------------------------
+
+const EXIT_OK: i32 = 0;
+const EXIT_USAGE: i32 = 1;
+const EXIT_PARTICIPANT: i32 = 2;
+const EXIT_DATA: i32 = 3;
+const EXIT_UNSUPPORTED: i32 = 4;
+
+// ---------------------------------------------------------------------------
+// Signal handling (async-signal-safe via signal-hook)
+// ---------------------------------------------------------------------------
+
+static ALL_DONE: AtomicBool = AtomicBool::new(false);
+
+fn install_signal_handlers() -> Result<(), String> {
+    // signal-hook installs an async-signal-safe handler. The store on
+    // ALL_DONE is the only thing executed on the signal path. We register
+    // the same callback for SIGINT and SIGTERM so the binary exits cleanly
+    // under `pkill` / Ctrl-C from the OMG harness.
+    unsafe {
+        register_signal(signal_hook::consts::SIGINT)?;
+        register_signal(signal_hook::consts::SIGTERM)?;
+    }
+    Ok(())
+}
+
+unsafe fn register_signal(sig: i32) -> Result<(), String> {
+    signal_hook::low_level::register(sig, || {
+        ALL_DONE.store(true, Ordering::SeqCst);
+    })
+    .map(|_| ())
+    .map_err(|e| format!("low_level register({}) failed: {}", sig, e))
+}
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+/// Tri-state for OMG t/f/d flags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TriState {
+    /// Vendor implementation default - we don't change behavior.
+    Default,
+    True,
+    False,
+}
+
+impl TriState {
+    fn parse(s: &str) -> Result<Self, String> {
+        match s.to_lowercase().as_str() {
+            "t" | "true" | "1" => Ok(TriState::True),
+            "f" | "false" | "0" => Ok(TriState::False),
+            "d" | "default" => Ok(TriState::Default),
+            _ => Err(format!("expected t/f/d, got '{}'", s)),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Options {
+    domain_id: u32,
+    domain_id_from_cli: bool,
+    topic_name: String,
+    type_name: String,
+    type_folder: Option<String>,
+    type_file: Option<String>,
+    data_folder: Option<String>,
+    data_file: Option<String>,
+    publish: bool,
+    subscribe: bool,
+    reliability: String,
+    durability: String,
+    xcdr_version: u8,
+    print_writer_samples: bool,
+    verbose: bool,
+    // OMG behavior switches - currently captured for diagnostics only.
+    // None of these change HDDS wire behavior yet; binary fails hard when a
+    // test asks for behavior we don't implement (see `enforce_unsupported`).
+    //
+    // explicit_ignore_member_names: set when --ignore-member-names is present on
+    // the command line even if the value is 'd' (Default). This lets
+    // build_type_consistency() distinguish "user said d = spec default
+    // = ignore_member_names=false" from "user never mentioned the flag = use
+    // the permissive implementation default = ignore_member_names=true".
+    explicit_ignore_member_names: bool,
+    ignore_member_names: TriState,
+    ignore_seq_bounds: TriState,
+    ignore_str_bounds: TriState,
+    prevent_type_widening: TriState,
+    check_member_names: TriState,
+    check_seq_bounds: TriState,
+    check_str_bounds: TriState,
+    force_type_validation: TriState,
+    disable_type_info: bool,
+    type_object_version: u8,
+    // When set, print the TypeObject equivalence hash(es) to stdout and exit
+    // without creating a Participant (OMG dds-xtypes "typeid" test mode).
+    print_typeid: bool,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            domain_id: 0,
+            domain_id_from_cli: false,
+            topic_name: String::new(),
+            type_name: String::new(),
+            type_folder: None,
+            type_file: None,
+            data_folder: None,
+            data_file: None,
+            publish: false,
+            subscribe: false,
+            reliability: "reliable".to_string(),
+            durability: "volatile".to_string(),
+            xcdr_version: 2,
+            print_writer_samples: false,
+            verbose: false,
+            explicit_ignore_member_names: false,
+            ignore_member_names: TriState::Default,
+            ignore_seq_bounds: TriState::Default,
+            ignore_str_bounds: TriState::Default,
+            prevent_type_widening: TriState::Default,
+            check_member_names: TriState::Default,
+            check_seq_bounds: TriState::Default,
+            check_str_bounds: TriState::Default,
+            force_type_validation: TriState::Default,
+            disable_type_info: false,
+            type_object_version: 2,
+            print_typeid: false,
+        }
+    }
+}
+
+/// Helper: fetch the next argv and advance index. Reports a clear usage
+/// error if the value is missing.
+fn next_arg(args: &[String], i: &mut usize, flag: &str) -> Result<String, String> {
+    *i += 1;
+    args.get(*i)
+        .cloned()
+        .ok_or_else(|| format!("missing value for {}", flag))
+}
+
+fn parse_args(args: &[String]) -> Result<Options, String> {
+    let mut opts = Options::default();
+    let mut i = 1usize;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        match arg {
+            "-d" => {
+                let v = next_arg(args, &mut i, "-d")?;
+                opts.domain_id = v.parse::<u32>().map_err(|e| format!("-d: {}", e))?;
+                opts.domain_id_from_cli = true;
+            }
+            "-t" => opts.topic_name = next_arg(args, &mut i, "-t")?,
+            "-y" => opts.type_name = next_arg(args, &mut i, "-y")?,
+            "--type-folder" => opts.type_folder = Some(next_arg(args, &mut i, "--type-folder")?),
+            "--type-file" => opts.type_file = Some(next_arg(args, &mut i, "--type-file")?),
+            "--data-folder" => opts.data_folder = Some(next_arg(args, &mut i, "--data-folder")?),
+            "--data-file" => opts.data_file = Some(next_arg(args, &mut i, "--data-file")?),
+            "-P" => opts.publish = true,
+            "-S" => opts.subscribe = true,
+            "-r" => opts.reliability = next_arg(args, &mut i, "-r")?.to_lowercase(),
+            "-D" => opts.durability = next_arg(args, &mut i, "-D")?.to_lowercase(),
+            "-x" => {
+                let v = next_arg(args, &mut i, "-x")?;
+                opts.xcdr_version = v.parse::<u8>().map_err(|e| format!("-x: {}", e))?;
+            }
+            "-w" => opts.print_writer_samples = true,
+            "-v" => opts.verbose = true,
+            // OMG tri-state behavior flags.
+            "--ignore-member-names" => {
+                opts.ignore_member_names = TriState::parse(&next_arg(args, &mut i, arg)?)?;
+                opts.explicit_ignore_member_names = true;
+            }
+            "--ignore-seq-bounds" => {
+                opts.ignore_seq_bounds = TriState::parse(&next_arg(args, &mut i, arg)?)?;
+            }
+            "--ignore-str-bounds" => {
+                opts.ignore_str_bounds = TriState::parse(&next_arg(args, &mut i, arg)?)?;
+            }
+            "--prevent-type-widening" => {
+                opts.prevent_type_widening = TriState::parse(&next_arg(args, &mut i, arg)?)?;
+            }
+            "--check-member-names" => {
+                opts.check_member_names = TriState::parse(&next_arg(args, &mut i, arg)?)?;
+            }
+            "--check-seq-bounds" => {
+                opts.check_seq_bounds = TriState::parse(&next_arg(args, &mut i, arg)?)?;
+            }
+            "--check-str-bounds" => {
+                opts.check_str_bounds = TriState::parse(&next_arg(args, &mut i, arg)?)?;
+            }
+            "--force-type-validation" => {
+                opts.force_type_validation = TriState::parse(&next_arg(args, &mut i, arg)?)?;
+            }
+            "--disable-type-info" => opts.disable_type_info = true,
+            "--print-typeid" => opts.print_typeid = true,
+            "--type-object-version" => {
+                let v = next_arg(args, &mut i, "--type-object-version")?;
+                opts.type_object_version = v
+                    .parse::<u8>()
+                    .map_err(|e| format!("--type-object-version: {}", e))?;
+            }
+            "-h" | "--help" => {
+                print_help();
+                std::process::exit(EXIT_OK);
+            }
+            s => {
+                return Err(format!(
+                    "unknown argument '{}' (use --help to list supported flags)",
+                    s
+                ));
+            }
+        }
+        i += 1;
+    }
+    Ok(opts)
+}
+
+fn print_help() {
+    println!(
+        "Usage: hdds_xtypes_shape_main_linux [OPTIONS] -P|-S\n\
+\n\
+Required:\n\
+  -P                          Publisher mode\n\
+  -S                          Subscriber mode\n\
+  -t <topic>                  DDS topic name\n\
+  -y <type>                   Fully qualified type name (e.g. Test::struct_f1)\n\
+  --type-folder <dir>         Folder containing types/xml/<name>.xml\n\
+  --type-file <name>          Type XML file basename (without .xml)\n\
+\n\
+Optional:\n\
+  -d <id>                     DDS domain id (default 0)\n\
+  -r <reliable|best_effort>   Reliability QoS (default reliable)\n\
+  -D <volatile|transient_local|persistent>   Durability QoS (default volatile)\n\
+  -x <1|2>                    XCDR version (default 2)\n\
+  -w                          Print sample on every write\n\
+  -v                          Verbose logging\n\
+  --data-folder <dir>         Folder containing data/xml/<name>.xml\n\
+  --data-file <name>          Data XML file basename (without .xml)\n\
+\n\
+OMG behavior flags (t=true, f=false, d=vendor default):\n\
+  --ignore-member-names <t|f|d>\n\
+  --ignore-seq-bounds   <t|f|d>\n\
+  --ignore-str-bounds   <t|f|d>\n\
+  --prevent-type-widening <t|f|d>\n\
+  --check-member-names  <t|f|d>\n\
+  --check-seq-bounds    <t|f|d>\n\
+  --check-str-bounds    <t|f|d>\n\
+  --force-type-validation <t|f|d>\n\
+  --disable-type-info\n\
+\n\
+TypeObject hash mode:\n\
+  --print-typeid              Print TypeObject equivalence hash(es) and exit\n\
+  --type-object-version <1|2> Hash version (default 2; V1 vendor-specific)\n\
+\n\
+Environment:\n\
+  HDDS_DOMAIN_ID              Override domain id (only when -d is not given)\n"
+    );
+}
+
+/// Warn when the OMG harness passes behavior switches that are only partially
+/// implemented. The switches are now wired into `TypeConsistencyEnforcement`
+/// and propagated via SEDP `PID_TYPE_CONSISTENCY_ENFORCEMENT` (0x0074) so
+/// that remote endpoints receive the declared coercion policy. However, the
+/// local assignability checks in `is_assignable_to` / `is_type_compatible`
+/// do not yet branch on these flags at match time — tests that depend on
+/// HDDS changing its own local matching behavior based on the flags may still
+/// fail. Tests where the flag value matches the spec default (no-op) should
+/// pass. `--disable-type-info` is not yet plumbed at all.
+fn enforce_unsupported(opts: &Options) {
+    // Only flag switches whose local-matching semantics are unimplemented.
+    // The SEDP wire emission is handled via build_type_consistency(); the
+    // remaining gap is that HDDS does not alter its own matcher decisions
+    // based on the received/local TypeConsistencyEnforcement policy.
+    let partial_wire_only: &[&str] = &[
+        // Wire-emitted correctly but local matcher ignores:
+    ];
+    let _ = partial_wire_only; // for future use
+
+    // disable-type-info: suppresses TypeObject emission in SEDP; now implemented.
+    // No warning needed — run_publisher/run_subscriber pass None for type_object.
+}
+
+// ---------------------------------------------------------------------------
+// QoS mapping
+// ---------------------------------------------------------------------------
+
+/// Derive a `TypeConsistencyEnforcement` policy from the OMG harness CLI flags.
+///
+/// Maps `TriState` values to the DDS-XTypes §7.6.3.4 fields.
+///
+/// Distinction between "no flag" and "--ignore-member-names d":
+///   - No flag at all: use HDDS permissive default (ignore_member_names=true).
+///     Returns None; the SEDP builder emits the wire default bytes
+///     (ignore_member_names=true). Peer sees permissive behavior.
+///   - "--ignore-member-names d" (opts.explicit_ignore_member_names=true,
+///     value=Default): user requested the spec strict default
+///     (ignore_member_names=false per XTypes §7.6.3.4). Emits a PID with
+///     ignore_member_names=false so peers correctly apply name enforcement.
+///
+/// This distinction is why opts.explicit_ignore_member_names is checked
+/// separately from opts.ignore_member_names != TriState::Default.
+fn build_type_consistency(opts: &Options) -> Option<TypeConsistencyEnforcement> {
+    // Resolve each flag: Default -> spec default, True/False -> override.
+    let ignore_sequence_bounds = match opts.ignore_seq_bounds {
+        TriState::True => true,
+        TriState::False => false,
+        TriState::Default => true, // spec default
+    };
+    let ignore_string_bounds = match opts.ignore_str_bounds {
+        TriState::True => true,
+        TriState::False => false,
+        TriState::Default => true, // spec default
+    };
+    let ignore_member_names = match opts.ignore_member_names {
+        TriState::True => true,
+        TriState::False => false,
+        TriState::Default => false, // spec default per XTypes §7.6.3.4
+    };
+    let prevent_type_widening = match opts.prevent_type_widening {
+        TriState::True => true,
+        TriState::False => false,
+        TriState::Default => false, // spec default
+    };
+    let force_type_validation = match opts.force_type_validation {
+        TriState::True => true,
+        TriState::False => false,
+        TriState::Default => false, // spec default
+    };
+
+    // Check flags are non-default; also honour check_* flags which are the
+    // inverse semantics of ignore_*: check_seq_bounds=true <-> ignore_seq_bounds=false.
+    // explicit_ignore_member_names triggers policy emission even when the value
+    // is Default, so peers receive ignore_member_names=false (spec strict default).
+    let any_explicit = opts.explicit_ignore_member_names
+        || opts.ignore_seq_bounds != TriState::Default
+        || opts.ignore_str_bounds != TriState::Default
+        || opts.ignore_member_names != TriState::Default
+        || opts.prevent_type_widening != TriState::Default
+        || opts.force_type_validation != TriState::Default
+        || opts.check_seq_bounds != TriState::Default
+        || opts.check_str_bounds != TriState::Default
+        || opts.check_member_names != TriState::Default;
+
+    if !any_explicit {
+        return None;
+    }
+
+    // Resolve --check-* flags: check_seq_bounds=t -> ignore_sequence_bounds=false.
+    let ignore_sequence_bounds = if opts.check_seq_bounds == TriState::True {
+        false
+    } else {
+        ignore_sequence_bounds
+    };
+    let ignore_string_bounds = if opts.check_str_bounds == TriState::True {
+        false
+    } else {
+        ignore_string_bounds
+    };
+    let ignore_member_names = if opts.check_member_names == TriState::True {
+        false
+    } else {
+        ignore_member_names
+    };
+
+    // kind: DISALLOW_TYPE_COERCION when ignore_seq+str are both false AND
+    // prevent_type_widening is true; otherwise ALLOW_TYPE_COERCION.
+    let kind: u16 = if !ignore_sequence_bounds && !ignore_string_bounds && !ignore_member_names
+        && prevent_type_widening
+    {
+        0 // DISALLOW_TYPE_COERCION
+    } else {
+        1 // ALLOW_TYPE_COERCION
+    };
+
+    Some(TypeConsistencyEnforcement {
+        kind,
+        ignore_sequence_bounds,
+        ignore_string_bounds,
+        ignore_member_names,
+        prevent_type_widening,
+        force_type_validation,
+    })
+}
+
+/// Build the DDS QoS used by writer and reader.
+///
+/// Defaults (matching the OMG reference C++ binary `test_main.cxx`
+/// `TestOptions()` constructor at /tmp/dds-xtypes-recon/src/cxx/test_main.cxx
+/// lines 290-294):
+///
+/// - Reliability = RELIABLE  (overridable via `-r best_effort`)
+/// - Durability  = VOLATILE  (overridable via `-D transient_local|...`)
+/// - DataRepresentation explicit list derived from `-x`. The OMG harness
+///   `interoperability_report.py` always injects `-x <1|2>` (default "2",
+///   line 778) when the test case does not set it, so this field is
+///   effectively never empty in a harness run. Setting it explicitly here
+///   makes HDDS' SEDP `PID_DATA_REPRESENTATION` carry the exact list every
+///   peer expects.
+/// Map the harness `-x` flag to the CDR version used by the dynamic codec.
+/// The harness always injects `-x <1|2>` (default 2); both peers of a test
+/// case get the same value, so encode and decode agree.
+fn cdr_version_of(opts: &Options) -> CdrVersion {
+    if opts.xcdr_version == 1 {
+        CdrVersion::Xcdr1
+    } else {
+        CdrVersion::Xcdr2
+    }
+}
+
+fn build_qos(opts: &Options) -> QoS {
+    let base = match opts.reliability.as_str() {
+        "best_effort" | "besteffort" | "be" => QoS::best_effort(),
+        _ => QoS::reliable(),
+    };
+
+    let with_durability = match opts.durability.as_str() {
+        "transient_local" | "transientlocal" | "tl" => base.transient_local(),
+        "transient" => base.transient_local(),
+        "persistent" => base.transient_local(),
+        _ => base.volatile(),
+    };
+
+    // Pin DataRepresentation so the SEDP PID matches the encapsulation byte
+    // the ENGINE prepends inside write_raw (the driver passes bare CDR).
+    // Without this, HDDS' RTI dialect emits PID_DATA_REPRESENTATION =
+    // [XCDR2] only (see hdds protocol/dialect/rti/sedp/metadata.rs
+    // write_data_representation) regardless of `-x 1`, which would silently
+    // disagree with the wire encapsulation when the user asks for XCDR1.
+    let with_repr = match opts.xcdr_version {
+        1 => with_durability.data_representation_xcdr1(),
+        _ => with_durability.data_representation_xcdr2(),
+    };
+
+    // Wire the TypeConsistencyEnforcementQosPolicy derived from the OMG
+    // harness CLI flags into the QoS so SEDP propagates the caller's intent.
+    let mut qos = with_repr;
+    qos.type_consistency = build_type_consistency(opts);
+    qos
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+/// Print the TypeObject equivalence hash(es) for a type and exit (OMG
+/// dds-xtypes "typeid" test mode).
+///
+/// V2 prints the Minimal and Complete TypeObject equivalence hashes (MD5 of the
+/// CDR2-serialised TypeObject truncated to 14 bytes, per XTypes v1.3 §7.3.4.8),
+/// lowercase hex, matching the reference vendor output format exactly:
+///   `Minimal Type Object V2 - Equivalence Hash: <28 hex>`
+///   `Complete Type Object V2 - Equivalence Hash: <28 hex>`
+///
+/// V1 TypeIdentifiers are vendor-specific (different vendors emit different
+/// uint64 for the same type) and are manifest-excluded for HDDS, so V1 prints a
+/// single placeholder line and is documented as unsupported.
+fn print_typeid_and_exit(type_desc: &Arc<hdds::dynamic::TypeDescriptor>, version: u8) -> ! {
+    let cto = match type_descriptor_to_xtypes(type_desc) {
+        Some(c) => c,
+        None => {
+            eprintln!("ERROR: cannot build CompleteTypeObject");
+            std::process::exit(EXIT_DATA);
+        }
+    };
+    if version == 1 {
+        // V1 Type ID is vendor-specific and manifest-excluded for HDDS.
+        println!("Type Object V1 - Type ID: 0");
+        std::process::exit(EXIT_OK);
+    }
+    // DEBUG-ONLY falsification path: when HDDS_TYPEID_DEBUG is set, dump the raw
+    // inner CDR2-LE bytes (no outer TypeObject union wrapper) so candidate
+    // wrappings can be MD5-tested against reference hashes offline.
+    if std::env::var_os("HDDS_TYPEID_DEBUG").is_some() {
+        if let Some((c_bytes, m_bytes)) = hdds::dynamic::debug_type_object_inner_cdr2(&cto) {
+            let hex = |b: &[u8]| b.iter().map(|x| format!("{:02x}", x)).collect::<String>();
+            eprintln!("DEBUG inner CDR2 complete len={} hex={}", c_bytes.len(), hex(&c_bytes));
+            eprintln!("DEBUG inner CDR2 minimal  len={} hex={}", m_bytes.len(), hex(&m_bytes));
+        } else {
+            eprintln!("DEBUG inner CDR2: unavailable for this type variant");
+        }
+    }
+    // Minimal hash is derived from the Minimal-reference CompleteTypeObject
+    // (`cto`). The Complete hash must come from a CompleteTypeObject whose
+    // hash-based members (enums, nested-struct collection elements) are
+    // referenced by their Complete equivalence hash, per DDS-XTypes v1.3
+    // §7.3.4.5 / §7.3.4.8.
+    let cto_complete = match type_descriptor_to_xtypes_complete(type_desc) {
+        Some(c) => c,
+        None => {
+            eprintln!("ERROR: cannot build Complete CompleteTypeObject");
+            std::process::exit(EXIT_DATA);
+        }
+    };
+    let complete = cto_complete.compute_equivalence_hash();
+    let minimal = hdds::dynamic::complete_type_object_minimal_hash(&cto);
+    match (minimal, complete) {
+        (Some(m), Ok(c)) => {
+            println!("Minimal Type Object V2 - Equivalence Hash: {}", m);
+            println!("Complete Type Object V2 - Equivalence Hash: {}", c);
+            std::process::exit(EXIT_OK);
+        }
+        _ => {
+            eprintln!("ERROR: cannot compute equivalence hash");
+            std::process::exit(EXIT_DATA);
+        }
+    }
+}
+
+fn main() {
+    let _ = env_logger::try_init();
+    if let Err(e) = install_signal_handlers() {
+        eprintln!("ERROR: {}", e);
+        std::process::exit(EXIT_PARTICIPANT);
+    }
+
+    let args: Vec<String> = std::env::args().collect();
+    let opts = match parse_args(&args) {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("ERROR: {}", e);
+            std::process::exit(EXIT_USAGE);
+        }
+    };
+
+    // OMG dds-xtypes "typeid" test mode: print the TypeObject equivalence
+    // hash(es) for the requested type and exit. This path does NOT require -t
+    // (topic) nor -P/-S (role) and never creates a Participant; it only needs
+    // the type loaded from XML (-y plus --type-folder/--type-file).
+    if opts.print_typeid {
+        if opts.type_name.is_empty() {
+            eprintln!("ERROR: type name (-y) required for --print-typeid");
+            std::process::exit(EXIT_USAGE);
+        }
+        let type_xml_path = match (&opts.type_folder, &opts.type_file) {
+            (Some(folder), Some(file)) => format!("{}/xml/{}.xml", folder, file),
+            _ => {
+                eprintln!("ERROR: --type-folder and --type-file are required");
+                std::process::exit(EXIT_USAGE);
+            }
+        };
+        let type_desc = match load_type_from_xml(&type_xml_path, &opts.type_name) {
+            Ok(td) => Arc::new(td),
+            Err(e) => {
+                eprintln!(
+                    "ERROR loading type '{}' from '{}': {}",
+                    opts.type_name, type_xml_path, e
+                );
+                std::process::exit(EXIT_DATA);
+            }
+        };
+        print_typeid_and_exit(&type_desc, opts.type_object_version);
+    }
+
+    if opts.topic_name.is_empty() {
+        eprintln!("ERROR: topic name (-t) required");
+        std::process::exit(EXIT_USAGE);
+    }
+    if opts.type_name.is_empty() {
+        eprintln!("ERROR: type name (-y) required");
+        std::process::exit(EXIT_USAGE);
+    }
+    if !opts.publish && !opts.subscribe {
+        eprintln!("ERROR: must specify -P (publish) or -S (subscribe)");
+        std::process::exit(EXIT_USAGE);
+    }
+
+    enforce_unsupported(&opts);
+
+    // Resolve type XML path
+    let type_xml_path = match (&opts.type_folder, &opts.type_file) {
+        (Some(folder), Some(file)) => Some(format!("{}/xml/{}.xml", folder, file)),
+        _ => None,
+    };
+
+    // Load type descriptor
+    let type_desc = match &type_xml_path {
+        Some(path) => match load_type_from_xml(path, &opts.type_name) {
+            Ok(td) => Arc::new(td),
+            Err(e) => {
+                eprintln!(
+                    "ERROR loading type '{}' from '{}': {}",
+                    opts.type_name, path, e
+                );
+                std::process::exit(EXIT_DATA);
+            }
+        },
+        None => {
+            eprintln!("ERROR: --type-folder and --type-file are required");
+            std::process::exit(EXIT_USAGE);
+        }
+    };
+
+    if opts.verbose {
+        println!("Loaded type: {}", type_desc.name);
+    }
+
+    // Build participant.
+    // Precedence: -d on the CLI wins. Only fall back to HDDS_DOMAIN_ID if
+    // -d was not passed. Log the source so a stale env var cannot silently
+    // change the domain (F-HDDS_DOMAIN_ID).
+    let (domain_id, domain_source) = if opts.domain_id_from_cli {
+        (opts.domain_id, "cli")
+    } else if let Some(env_val) = std::env::var("HDDS_DOMAIN_ID")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+    {
+        (env_val, "env")
+    } else {
+        (opts.domain_id, "default")
+    };
+    if opts.verbose {
+        println!("Domain id {} (source: {})", domain_id, domain_source);
+    }
+
+    let participant = match Participant::builder("hdds-xtypes-interop")
+        .domain_id(domain_id)
+        .with_transport(TransportMode::UdpMulticast)
+        .build()
+    {
+        Ok(p) => Arc::new(p),
+        Err(e) => {
+            eprintln!("ERROR creating participant: {}", e);
+            std::process::exit(EXIT_PARTICIPANT);
+        }
+    };
+
+    // Pre-populate the participant type store with ALL types from the XML file
+    // so the structural-assignability resolver can look up nested complex types
+    // (e.g. E1 enum when the local type is E2-based) at match time.
+    //
+    // This is feature-gated behind "xtypes-structural-assignability": when the
+    // feature is OFF the block compiles away and the participant type store is
+    // never touched, preserving byte-identical behavior with the baseline binary.
+    #[cfg(feature = "xtypes-structural-assignability")]
+    if let Some(ref path) = type_xml_path {
+        use std::collections::hash_map::Entry;
+        let mut nested: std::collections::HashMap<
+            hdds::xtypes::EquivalenceHash,
+            hdds::xtypes::CompleteTypeObject,
+        > = std::collections::HashMap::new();
+        // Qualified type name -> Minimal hash of the structure that OWNS the
+        // name in the store. Guards name-recourse soundness across files.
+        let mut known_names: std::collections::HashMap<String, hdds::xtypes::EquivalenceHash> =
+            std::collections::HashMap::new();
+
+        // The app's own type file is loaded FIRST (its types always win name
+        // conflicts), then every sibling XML type file from the same folder
+        // in sorted (deterministic) order. Reference vendor test binaries
+        // compile the ENTIRE suite's types in, so any announced peer type
+        // name is resolvable on their side; loading the sibling files gives
+        // the HDDS structural-assignability resolver the same local type
+        // knowledge (e.g. union_uint32_key from unions_key_discriminator.xml
+        // when the app itself runs with --type-file unions).
+        let mut files: Vec<std::path::PathBuf> = vec![std::path::PathBuf::from(path)];
+        if let Some(dir) = std::path::Path::new(path.as_str()).parent() {
+            if let Ok(rd) = std::fs::read_dir(dir) {
+                let mut siblings: Vec<std::path::PathBuf> = rd
+                    .filter_map(|e| e.ok())
+                    .map(|e| e.path())
+                    .filter(|p| p.extension().map(|x| x == "xml").unwrap_or(false))
+                    .filter(|p| p != &files[0])
+                    .collect();
+                siblings.sort();
+                files.extend(siblings);
+            }
+        }
+
+        for file in &files {
+            let Some(file_str) = file.to_str() else {
+                continue;
+            };
+            let Ok(all_types) = xml_loader::load_all_types_from_xml(file_str) else {
+                // Sibling file the loader cannot parse: skip it entirely;
+                // resolution for its types keeps the absent -> allow behavior.
+                continue;
+            };
+            for td in &all_types {
+                let td_arc = Arc::new(td.clone());
+                // Collect nested enums/structs/bitmasks keyed by Minimal hash.
+                hdds::dynamic::collect_nested_type_objects(&td_arc, &mut nested);
+                // Also register the top-level type itself.
+                let Some(to) = type_descriptor_to_xtypes(&td_arc) else {
+                    continue;
+                };
+                let Some(hash) = hdds::dynamic::complete_type_object_minimal_hash(&to) else {
+                    continue;
+                };
+                if let Some(name) = to.type_name() {
+                    match known_names.entry(name.to_string()) {
+                        Entry::Occupied(owner) => {
+                            // Name already owned by an earlier file. Same hash
+                            // means an identical structure (harmless duplicate,
+                            // already resolvable). A DIFFERENT hash means two
+                            // files declare conflicting shapes under one name:
+                            // skip this one (first/primary file wins) so
+                            // name-recourse resolution can never hand the
+                            // matcher a wrong structure.
+                            let _ = owner;
+                            continue;
+                        }
+                        Entry::Vacant(slot) => {
+                            slot.insert(hash);
+                        }
+                    }
+                }
+                match nested.entry(hash) {
+                    Entry::Vacant(slot) => {
+                        slot.insert(to);
+                    }
+                    Entry::Occupied(slot) => {
+                        // Same Minimal hash under a DIFFERENT type name:
+                        // structurally identical types (Minimal hashes exclude
+                        // the type name, e.g. union_1 == union_3 == union_int32
+                        // in unions.xml). The first entry keeps the
+                        // Minimal-hash key; park each alias under its COMPLETE
+                        // equivalence hash (which includes the type name, so
+                        // aliases never collide) so the engine's SEDP
+                        // name-recourse resolution (resolve_type_by_name scans
+                        // store VALUES) still finds every announced type name.
+                        // Without this, a vendor announcing 'Test::union_int32'
+                        // missed resolution entirely (union_1 had evicted it)
+                        // and the matcher fell back to absent-TypeObject ->
+                        // allow, producing OK where INCONSISTENT_TOPIC is
+                        // expected.
+                        if slot.get().type_name() != to.type_name() {
+                            if let Ok(chash) = to.compute_equivalence_hash() {
+                                nested.entry(chash).or_insert(to);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        participant.register_nested_type_objects(nested);
+    }
+
+    println!("Create topic: {}", opts.topic_name);
+
+    let qos = build_qos(&opts);
+
+    if opts.publish {
+        run_publisher(&participant, &opts, &type_desc, qos);
+    } else {
+        run_subscriber(&participant, &opts, &type_desc, qos);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Publisher
+// ---------------------------------------------------------------------------
+
+fn run_publisher(
+    participant: &Arc<Participant>,
+    opts: &Options,
+    type_desc: &Arc<hdds::dynamic::TypeDescriptor>,
+    qos: QoS,
+) {
+    // Load data
+    let data_xml_path = match (&opts.data_folder, &opts.data_file) {
+        (Some(folder), Some(file)) => format!("{}/xml/{}.xml", folder, file),
+        _ => {
+            eprintln!("ERROR: --data-folder and --data-file required for publisher");
+            std::process::exit(EXIT_USAGE);
+        }
+    };
+
+    let data = match load_data_from_xml(&data_xml_path, type_desc) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("ERROR loading data from '{}': {}", data_xml_path, e);
+            std::process::exit(EXIT_DATA);
+        }
+    };
+
+    // Encode to CDR at the negotiated representation. The `-x` flag drives
+    // both the SEDP DataRepresentation PID and the encapsulation the engine
+    // prepends; the body alignment must match (XCDR2 caps primitive
+    // alignment at 4, DDS-XTypes v1.3 section 7.4.3.3).
+    let cdr_bytes = match encode_dynamic_with_version(&data, cdr_version_of(opts)) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("ERROR encoding CDR: {}", e);
+            std::process::exit(EXIT_DATA);
+        }
+    };
+
+    // Do NOT prepend an encapsulation header here. HDDS `write_raw` takes
+    // raw serialized CDR: the engine prepends the 4-byte header itself
+    // (derived from the type extensibility + the writer DataRepresentation,
+    // see hdds protocol/builder/packet.rs `encap_kind_for_version`) and the
+    // receiving router strips it before delivery. Prepending here doubles
+    // the header on the wire; peers then decode the second header as data
+    // (CoreDX/Cyclone read x1 = 0x0700 for struct_primitive_uint32). The
+    // read path keeps `strip_encapsulation` as an if-present no-op.
+    let payload = cdr_bytes;
+
+    // Create writer with type name override.
+    // When --disable-type-info is set, suppress the TypeObject from SEDP so the
+    // remote peer falls back to topic-name-only type matching (DDS-XTypes v1.3
+    // §7.6.3.4 force_type_validation semantics: without a TypeObject, structural
+    // assignability cannot be enforced and matching proceeds by name).
+    let type_object = if opts.disable_type_info {
+        None
+    } else {
+        type_descriptor_to_xtypes(type_desc)
+    };
+
+    // When the TypeObject is suppressed (--disable-type-info) the engine
+    // cannot derive the canonical XCDR2 encapsulation from extensibility
+    // flags and would default to PLAIN_CDR2 (0x0007) even though the body
+    // we encode above is DHEADER/EMHEADER-framed for appendable/mutable
+    // types. Steer the encapsulation explicitly from the local descriptor
+    // (DDS-XTypes v1.3 section 7.6.3.1.2: appendable -> D_CDR2 0x0009,
+    // mutable -> PL_CDR2 0x000B; final keeps the engine default). The
+    // engine still degrades to the XCDR1 codes when x1 is negotiated.
+    let encapsulation_kind = if opts.disable_type_info {
+        match type_desc.extensibility {
+            Extensibility::Appendable => Some(0x0009u16),
+            Extensibility::Mutable => Some(0x000Bu16),
+            Extensibility::Final => None,
+        }
+    } else {
+        None
+    };
+    println!(
+        "Create writer for topic: {} type: {}",
+        opts.topic_name, opts.type_name
+    );
+
+    let writer_listener = Arc::new(XtypesWriterListener::new());
+    let writer = match participant.create_raw_writer_with_type_and_encapsulation(
+        &opts.topic_name,
+        &opts.type_name,
+        Some(qos),
+        type_object,
+        encapsulation_kind,
+        Some(writer_listener),
+    ) {
+        Ok(w) => w,
+        Err(e) => {
+            eprintln!("ERROR creating writer: {}", e);
+            std::process::exit(EXIT_PARTICIPANT);
+        }
+    };
+
+    // Wait briefly for discovery
+    std::thread::sleep(Duration::from_millis(500));
+
+    while !ALL_DONE.load(Ordering::SeqCst) {
+        if let Err(e) = writer.write_raw(&payload) {
+            eprintln!("WARN write error: {}", e);
+        }
+        if opts.print_writer_samples {
+            println!("Wrote:");
+            print_dynamic_data(&data);
+        }
+        std::thread::sleep(Duration::from_secs(1));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Subscriber
+// ---------------------------------------------------------------------------
+
+fn run_subscriber(
+    participant: &Arc<Participant>,
+    opts: &Options,
+    type_desc: &Arc<hdds::dynamic::TypeDescriptor>,
+    qos: QoS,
+) {
+    // When --disable-type-info is set, suppress the TypeObject from SEDP so the
+    // remote peer falls back to topic-name-only type matching. Mirrors the
+    // publisher-side suppression; both sides must agree on omitting the TypeObject
+    // for the force_type_validation=false case to yield a successful match.
+    let type_object = if opts.disable_type_info {
+        None
+    } else {
+        type_descriptor_to_xtypes(type_desc)
+    };
+    println!(
+        "Create reader for topic: {} type: {}",
+        opts.topic_name, opts.type_name
+    );
+
+    let reader_listener = Arc::new(XtypesReaderListener::new());
+    let reader = match participant.create_raw_reader_with_type(
+        &opts.topic_name,
+        &opts.type_name,
+        Some(qos),
+        type_object,
+        Some(reader_listener),
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("ERROR creating reader: {}", e);
+            std::process::exit(EXIT_PARTICIPANT);
+        }
+    };
+
+    // Expected data for check
+    let expected_data = match (&opts.data_folder, &opts.data_file) {
+        (Some(folder), Some(file)) => {
+            let path = format!("{}/xml/{}.xml", folder, file);
+            match load_data_from_xml(&path, type_desc) {
+                Ok(d) => Some(d),
+                Err(e) => {
+                    eprintln!("WARN could not load expected data: {}", e);
+                    None
+                }
+            }
+        }
+        _ => None,
+    };
+
+    let mut received_ok = false;
+
+    while !ALL_DONE.load(Ordering::SeqCst) {
+        match reader.try_take_raw() {
+            Ok(samples) => {
+                for raw in samples {
+                    // The HDDS router already strips the 4-byte encapsulation
+                    // header before delivery (route_data_packet /
+                    // route_reassembled_data), so `raw.payload` is bare CDR.
+                    // Do NOT run strip_encapsulation here: its if-present
+                    // heuristic corrupts samples whose first bytes mimic a
+                    // header (e.g. a union discriminant 0 -> `00 00` reads
+                    // as CDR_BE and 4 data bytes get eaten).
+                    let payload = raw.payload.as_slice();
+                    match decode_dynamic_with_version(payload, type_desc, cdr_version_of(opts)) {
+                        Ok(decoded) => {
+                            // Print after successful decode: harness uses this
+                            // line to determine the subscriber received a sample.
+                            // Emitting it before decode would cause DATA_NOT_CORRECT
+                            // for tryConstruct=Discard samples that are silently
+                            // dropped (DDS-XTypes v1.3 §7.5.1.4).
+                            println!("sample_received()");
+                            print_dynamic_data(&decoded);
+                            if let Some(ref expected) = expected_data {
+                                if compare_dynamic_data(&decoded, expected) {
+                                    println!("Received sample is the same as loaded");
+                                    received_ok = true;
+                                } else {
+                                    println!("Received sample is not the same as loaded");
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            // Decode failed: policy (Discard) or corrupt wire data.
+                            // Do not announce sample_received() so the harness
+                            // observes DATA_NOT_RECEIVED instead of DATA_NOT_CORRECT.
+                            eprintln!("WARN CDR decode error: {}", e);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("WARN read error: {}", e);
+            }
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let _ = received_ok;
+}
+
+// ---------------------------------------------------------------------------
+// Print helper
+// ---------------------------------------------------------------------------
+
+fn print_dynamic_data(data: &DynamicData) {
+    use hdds::dynamic::DynamicValue;
+
+    fn print_value(indent: usize, name: &str, val: &DynamicValue) {
+        let pad = " ".repeat(indent * 2);
+        match val {
+            DynamicValue::Struct(fields) => {
+                println!("{}{} {{", pad, name);
+                for (k, v) in fields {
+                    print_value(indent + 1, k, v);
+                }
+                println!("{}}}", pad);
+            }
+            DynamicValue::Sequence(elems) | DynamicValue::Array(elems) => {
+                println!("{}{} [", pad, name);
+                for (i, v) in elems.iter().enumerate() {
+                    print_value(indent + 1, &i.to_string(), v);
+                }
+                println!("{}]", pad);
+            }
+            DynamicValue::Bool(v) => println!("{}{}: {}", pad, name, v),
+            DynamicValue::U8(v) => println!("{}{}: {}", pad, name, v),
+            DynamicValue::U16(v) => println!("{}{}: {}", pad, name, v),
+            DynamicValue::U32(v) => println!("{}{}: {}", pad, name, v),
+            DynamicValue::U64(v) => println!("{}{}: {}", pad, name, v),
+            DynamicValue::I8(v) => println!("{}{}: {}", pad, name, v),
+            DynamicValue::I16(v) => println!("{}{}: {}", pad, name, v),
+            DynamicValue::I32(v) => println!("{}{}: {}", pad, name, v),
+            DynamicValue::I64(v) => println!("{}{}: {}", pad, name, v),
+            DynamicValue::F32(v) => println!("{}{}: {}", pad, name, v),
+            DynamicValue::F64(v) => println!("{}{}: {}", pad, name, v),
+            DynamicValue::LongDouble(v) => println!(
+                "{}{}: {}",
+                pad,
+                name,
+                crate::data_loader::binary128_le_to_f64(v)
+            ),
+            // escape_default() keeps control bytes (e.g. char8 value 0x01 from
+            // struct_char_x1) out of stdout: a raw control char captured into the
+            // OMG harness junit makes junitparser/lxml reject the whole report
+            // ("no control characters") and HDDS would score zero on the CI.
+            DynamicValue::Char(v) => println!("{}{}: '{}'", pad, name, v.escape_default()),
+            DynamicValue::String(v) | DynamicValue::WString(v) => {
+                println!("{}{}: \"{}\"", pad, name, v.escape_default())
+            }
+            DynamicValue::Enum(val, name2) => println!("{}{}: {}({})", pad, name, name2, val),
+            DynamicValue::Union(disc, case, inner) => {
+                println!("{}{}: union[disc={}][{}]", pad, name, disc, case);
+                print_value(indent + 1, case, inner);
+            }
+            DynamicValue::Null => println!("{}{}: null", pad, name),
+        }
+    }
+
+    print_value(0, data.type_name(), data.value());
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(input: &[&str]) -> Vec<String> {
+        std::iter::once("hdds_xtypes_shape_main_linux".to_string())
+            .chain(input.iter().map(|s| s.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn parses_basic_publisher_args() {
+        let v = args(&[
+            "-P",
+            "-d",
+            "42",
+            "-t",
+            "Test",
+            "-y",
+            "Test::struct_f1",
+            "--type-folder",
+            "/tmp/types",
+            "--type-file",
+            "extensibility",
+        ]);
+        let o = parse_args(&v).expect("parse");
+        assert!(o.publish);
+        assert!(!o.subscribe);
+        assert_eq!(o.domain_id, 42);
+        assert!(o.domain_id_from_cli);
+        assert_eq!(o.topic_name, "Test");
+        assert_eq!(o.type_name, "Test::struct_f1");
+        assert_eq!(o.type_folder.as_deref(), Some("/tmp/types"));
+    }
+
+    #[test]
+    fn tri_state_parsing() {
+        assert_eq!(TriState::parse("t").unwrap(), TriState::True);
+        assert_eq!(TriState::parse("T").unwrap(), TriState::True);
+        assert_eq!(TriState::parse("true").unwrap(), TriState::True);
+        assert_eq!(TriState::parse("f").unwrap(), TriState::False);
+        assert_eq!(TriState::parse("0").unwrap(), TriState::False);
+        assert_eq!(TriState::parse("d").unwrap(), TriState::Default);
+        assert!(TriState::parse("xyz").is_err());
+    }
+
+    #[test]
+    fn unknown_arg_is_error_not_silent() {
+        let v = args(&["-P", "-t", "T", "-y", "Y", "--bogus-flag", "value"]);
+        let err = parse_args(&v).unwrap_err();
+        assert!(err.contains("--bogus-flag"));
+    }
+
+    #[test]
+    fn missing_value_is_error() {
+        let v = args(&["-P", "-t"]);
+        let err = parse_args(&v).unwrap_err();
+        assert!(err.contains("missing value"));
+    }
+
+    #[test]
+    fn captures_omg_behavior_flags() {
+        let v = args(&[
+            "-S",
+            "-t",
+            "T",
+            "-y",
+            "Y",
+            "--ignore-member-names",
+            "t",
+            "--ignore-seq-bounds",
+            "f",
+            "--ignore-str-bounds",
+            "d",
+            "--force-type-validation",
+            "t",
+            "--disable-type-info",
+        ]);
+        let o = parse_args(&v).expect("parse");
+        assert_eq!(o.ignore_member_names, TriState::True);
+        assert_eq!(o.ignore_seq_bounds, TriState::False);
+        assert_eq!(o.ignore_str_bounds, TriState::Default);
+        assert_eq!(o.force_type_validation, TriState::True);
+        assert!(o.disable_type_info);
+    }
+
+    #[test]
+    fn domain_id_default_is_not_from_cli() {
+        let v = args(&["-P", "-t", "T", "-y", "Y"]);
+        let o = parse_args(&v).expect("parse");
+        assert_eq!(o.domain_id, 0);
+        assert!(!o.domain_id_from_cli);
+    }
+
+    // Verify that decode_dynamic returns Err for an enum value absent from the
+    // local type when the field carries TryConstructKind::Discard (the default
+    // per DDS-XTypes v1.3 §7.2.2.4.1.2 Table 9).  This is the precondition for
+    // the subscriber loop to suppress sample_received() and let the harness
+    // observe DATA_NOT_RECEIVED instead of DATA_NOT_CORRECT.
+    //
+    // E2 (local): VAL0=0, VAL1=1(default), VAL2=2
+    // Wire enum value: 3 (VAL3) -- present in E1 but not in E2.
+    #[test]
+    fn decode_unknown_enum_discard_returns_err() {
+        use hdds::dynamic::{
+            decode_dynamic, EnumDescriptor, EnumVariant, Extensibility, FieldDescriptor,
+            TryConstructKind, TypeDescriptor, TypeKind,
+        };
+        use std::sync::Arc;
+
+        // Build E2: three variants, VAL1 is the defaultLiteral.
+        let e2 = Arc::new(TypeDescriptor::new(
+            "E2",
+            TypeKind::Enum(EnumDescriptor::new(vec![
+                EnumVariant::new("VAL0", 0),
+                EnumVariant::new("VAL1", 1).with_default_literal(),
+                EnumVariant::new("VAL2", 2),
+            ])),
+        ));
+
+        // Struct with one E2 field, TryConstruct=Discard (default).
+        let discard_desc = Arc::new(
+            TypeDescriptor::struct_type(
+                "struct_enum_2_discard",
+                vec![FieldDescriptor::new("x1", e2.clone())],
+            )
+            .with_extensibility(Extensibility::Mutable),
+        );
+
+        // Wire: mutable struct -- EMHEADER(x1, LC=2, id=0) + enum value=3 (unknown in E2).
+        // EMHEADER: LC=2 -> (2<<28) | member_id=0 = 0x2000_0000
+        // Enum: 4 bytes little-endian = 3u32
+        let mut wire: Vec<u8> = Vec::new();
+        wire.extend(&0x2000_0000u32.to_le_bytes()); // EMHEADER
+        wire.extend(&3u32.to_le_bytes()); // enum value VAL3, not in E2
+        wire.extend(&0x3FFF_FFFFu32.to_le_bytes()); // sentinel
+
+        // Discard policy: decode must fail.
+        assert!(
+            decode_dynamic(&wire, &discard_desc).is_err(),
+            "Discard policy: unknown enum value must produce Err"
+        );
+
+        // UseDefault policy: decode must succeed and return the defaultLiteral (VAL1=1).
+        let use_default_desc = Arc::new(
+            TypeDescriptor::struct_type(
+                "struct_enum_2_default",
+                vec![FieldDescriptor::new("x1", e2.clone())
+                    .with_try_construct(TryConstructKind::UseDefault)],
+            )
+            .with_extensibility(Extensibility::Mutable),
+        );
+
+        let decoded = decode_dynamic(&wire, &use_default_desc)
+            .expect("UseDefault policy: unknown enum value must produce Ok with default variant");
+        // The default variant is VAL1 (value=1).
+        match decoded.get_field("x1").expect("x1 field present") {
+            hdds::dynamic::DynamicValue::Enum(v, _) => {
+                assert_eq!(*v, 1, "UseDefault must map unknown enum to defaultLiteral (VAL1=1)");
+            }
+            other => panic!("expected Enum variant, got {:?}", other),
+        }
+    }
+}

--- a/src/rs/HDDS/src/xml_loader.rs
+++ b/src/rs/HDDS/src/xml_loader.rs
@@ -1,0 +1,1677 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (c) 2025-2026 naskel.com
+
+//! DDS-XML type loader.
+//!
+//! Parses the OMG DDS-XML format used by the dds-xtypes interoperability test
+//! suite. The grammar supported is:
+//!
+//!   <dds><types>
+//!     <module name="Test">
+//!       <struct name="foo" extensibility="final|appendable|mutable">
+//!         <member name="x1" type="int32" [id="N"] [sequenceMaxLength="-1|N"]
+//!                 [arrayDimensions="N[,M]"] [stringMaxLength="N"] [optional="true"]/>
+//!       </struct>
+//!       <enum name="E1" [bitBound="8|16|32"]>
+//!         <enumerator name="VAL0" value="0"/>
+//!       </enum>
+//!       <union name="U1">
+//!         <discriminator type="uint8"/>
+//!         <case><caseDiscriminator value="1"/><member name="x1" type="int32"/></case>
+//!       </union>
+//!     </module>
+//!   </types></dds>
+//!
+//! Modules nest: <module name="A"><module name="B">...</module></module> yields
+//! qualified names like "A::B::Type". Both the fully qualified and the bare
+//! local name resolve to a type, with fully qualified taking priority on
+//! collisions.
+//!
+//! Known unsupported grammar (documented in README.md "Known Blockers"):
+//!   - typedef, bitset, annotation, autoid, hashid, mustUnderstand.
+//!   - extensibility is parsed and propagated to TypeDescriptor.extensibility
+//!     for both struct and union types; the HDDS engine selects the wire
+//!     representation identifier (D_CDR2 / PL_CDR2) from it when it prepends
+//!     the encapsulation header inside write_raw (the driver sends bare CDR).
+//!   - tryConstruct is parsed on struct members and union case members;
+//!     defaultLiteral is parsed on enum variants.
+//!   - caseDiscriminator value="default" is parsed and marks the case
+//!     as the union default (UnionDescriptor::default_case).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use hdds::dynamic::{
+    ArrayDescriptor, EnumDescriptor, EnumVariant, Extensibility, FieldDescriptor, PrimitiveKind,
+    SequenceDescriptor, TryConstructKind, TypeDescriptor, TypeKind, UnionCase, UnionDescriptor,
+};
+use quick_xml::events::Event;
+use quick_xml::reader::Reader;
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+pub fn load_type_from_xml(path: &str, type_name: &str) -> Result<TypeDescriptor, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read '{}': {}", path, e))?;
+    parse_type_xml(&content, type_name)
+}
+
+/// Load ALL type descriptors from an XML file.
+///
+/// Used by the structural-assignability resolver to pre-populate the
+/// participant type store with every type defined in the XML file — including
+/// types that are not the primary writer/reader type.  This lets the resolver
+/// answer hash lookups for nested enum or struct types that appear in the XML
+/// but are not the directly-requested type (e.g. E1 in arrays.xml when the
+/// driver is running as a subscriber for enum2x10).
+///
+/// Types that cannot be parsed (e.g. complex recursive aliases) are silently
+/// skipped; the returned Vec contains only successfully-built descriptors.
+pub fn load_all_types_from_xml(path: &str) -> Result<Vec<TypeDescriptor>, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read '{}': {}", path, e))?;
+    let types = collect_raw_types(&content)?;
+
+    let mut by_qualified: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    let mut by_local: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for (i, t) in types.iter().enumerate() {
+        by_qualified.insert(t.qualified_name(), i);
+        by_local.entry(t.local_name().to_string()).or_insert(i);
+    }
+
+    let mut result = Vec::new();
+    for raw in &types {
+        if let Ok(td) = raw_to_descriptor(raw, &types, &by_qualified, &by_local) {
+            result.push(td);
+        }
+    }
+    Ok(result)
+}
+
+// ---------------------------------------------------------------------------
+// XML parse
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+enum RawTypeDef {
+    Struct {
+        name: String,
+        module: String,
+        extensibility: String,
+        /// True when the struct carries `autoid="hash"` (DDS-XTypes §7.3.1.2).
+        autoid_hash: bool,
+        members: Vec<RawMember>,
+    },
+    Enum {
+        name: String,
+        module: String,
+        bit_bound: u8, // 8 / 16 / 32, defaults to 32 per IDL 4.2
+        variants: Vec<EnumVariant>,
+    },
+    /// Bitmask type: a set of named bit flags each with a bit position.
+    /// Represented as an enum where each variant value equals `1 << position`.
+    /// The `bit_bound` controls the underlying primitive width (8/16/32/64).
+    Bitmask {
+        name: String,
+        module: String,
+        bit_bound: u8,
+        /// (flag_name, bit_position)
+        flags: Vec<(String, u32)>,
+    },
+    Union {
+        name: String,
+        module: String,
+        extensibility: String,
+        discriminator_type: String,
+        /// Try-construct policy on the `<discriminator>` element (not the cases).
+        discriminator_try_construct: TryConstructKind,
+        /// Whether the discriminator carries `key="true"` (DDS-XML §7.3.4.6).
+        discriminator_is_key: bool,
+        cases: Vec<RawCase>,
+    },
+}
+
+impl RawTypeDef {
+    fn local_name(&self) -> &str {
+        match self {
+            Self::Struct { name, .. }
+            | Self::Enum { name, .. }
+            | Self::Bitmask { name, .. }
+            | Self::Union { name, .. } => name,
+        }
+    }
+
+    fn module(&self) -> &str {
+        match self {
+            Self::Struct { module, .. }
+            | Self::Enum { module, .. }
+            | Self::Bitmask { module, .. }
+            | Self::Union { module, .. } => module,
+        }
+    }
+
+
+    fn qualified_name(&self) -> String {
+        let m = self.module();
+        if m.is_empty() {
+            self.local_name().to_string()
+        } else {
+            format!("{}::{}", m, self.local_name())
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RawMember {
+    name: String,
+    type_str: String,
+    id: Option<u32>,
+    sequence_max: Option<i64>, // -1 = unbounded, else bound
+    array_dims: Vec<usize>,
+    string_max: Option<usize>,
+    optional: bool,
+    try_construct: TryConstructKind,
+    /// Value of the `hashid="alias"` attribute (DDS-XTypes §7.3.1.2.1.1).
+    /// When present, the hash of `alias` is used for the member ID and the
+    /// Minimal name_hash instead of the member's own `name`.
+    hashid: Option<String>,
+    /// `key="true"` — member participates in the DDS instance key.
+    is_key: bool,
+    /// `mustUnderstand="true"` — reader must understand this member.
+    is_must_understand: bool,
+}
+
+#[derive(Debug, Clone)]
+struct RawCase {
+    discriminator_values: Vec<i64>,
+    /// Unresolved string labels (enum variant names that could not be parsed
+    /// as integers at collection time; resolved in `raw_to_descriptor` once
+    /// the discriminator type is known).
+    discriminator_name_labels: Vec<String>,
+    /// True when one of the caseDiscriminator values was `"default"`.
+    is_default: bool,
+    member: RawMember,
+}
+
+fn parse_type_xml(xml: &str, type_name: &str) -> Result<TypeDescriptor, String> {
+    let types = collect_raw_types(xml)?;
+
+    // Build lookup: qualified takes priority; fall back to local but warn
+    // when a local-name collision exists across modules (last write wins is
+    // unsafe - we keep the *first* occurrence so the message stays
+    // deterministic and lookup by the unqualified name does not silently
+    // pick the wrong module's type).
+    let mut by_qualified: HashMap<String, usize> = HashMap::new();
+    let mut by_local: HashMap<String, usize> = HashMap::new();
+    for (i, t) in types.iter().enumerate() {
+        by_qualified.insert(t.qualified_name(), i);
+        // First-write-wins on the local index so a deterministic name
+        // collision still has a stable answer.
+        by_local.entry(t.local_name().to_string()).or_insert(i);
+    }
+
+    // Resolve the requested type
+    let idx = by_qualified
+        .get(type_name)
+        .or_else(|| by_local.get(type_name))
+        .copied()
+        .ok_or_else(|| {
+            let available: Vec<_> = types.iter().map(|t| t.qualified_name()).collect();
+            format!(
+                "type '{}' not found in XML; available: {}",
+                type_name,
+                available.join(", ")
+            )
+        })?;
+
+    raw_to_descriptor(&types[idx], &types, &by_qualified, &by_local)
+}
+
+// ---------------------------------------------------------------------------
+// Collect all raw type definitions
+// ---------------------------------------------------------------------------
+
+fn collect_raw_types(xml: &str) -> Result<Vec<RawTypeDef>, String> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut types: Vec<RawTypeDef> = Vec::new();
+
+    // Parsing state
+    let mut module_stack: Vec<String> = Vec::new();
+    let mut current_struct: Option<(String, String, bool, Vec<RawMember>)> = None; // (name, ext, autoid_hash, members)
+    let mut current_enum: Option<(String, u8, Vec<EnumVariant>)> = None; // (name, bit_bound, variants)
+    // (name, bit_bound, flags: Vec<(flag_name, bit_position)>)
+    let mut current_bitmask: Option<(String, u8, Vec<(String, u32)>)> = None;
+    // (name, ext, disc_type, disc_try_construct, disc_is_key, cases)
+    let mut current_union: Option<(String, String, String, TryConstructKind, bool, Vec<RawCase>)> = None;
+    // (int_labels, name_labels, is_default, member)
+    let mut current_case: Option<(Vec<i64>, Vec<String>, bool, Option<RawMember>)> = None;
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) => {
+                let tag = std::str::from_utf8(e.name().as_ref())
+                    .unwrap_or("")
+                    .to_lowercase();
+                let attrs = parse_attrs(e);
+
+                handle_open_tag(
+                    &tag,
+                    &attrs,
+                    &mut module_stack,
+                    &mut current_struct,
+                    &mut current_enum,
+                    &mut current_bitmask,
+                    &mut current_union,
+                    &mut current_case,
+                );
+            }
+            Ok(Event::Empty(ref e)) => {
+                let tag = std::str::from_utf8(e.name().as_ref())
+                    .unwrap_or("")
+                    .to_lowercase();
+                let attrs = parse_attrs(e);
+
+                // An empty element has no End event. Handle it like
+                // Start+End for child-data containers (member, enumerator,
+                // discriminator, caseDiscriminator). Container-style
+                // elements (module, struct, enum, union, case) cannot be
+                // empty - if encountered, push+immediate-pop so we do not
+                // leak the module stack (F-module-stack from the panel).
+                match tag.as_str() {
+                    "module" => {
+                        // <module/> opens and closes immediately. The OMG
+                        // corpus never uses this form but the spec allows
+                        // it, and the previous code leaked module_stack
+                        // here. We push and pop to keep the qualified-name
+                        // join() stable across nesting.
+                        let name = attrs.get("name").cloned().unwrap_or_default();
+                        module_stack.push(name);
+                        module_stack.pop();
+                    }
+                    "struct" | "enum" | "union" | "case" => {
+                        // Genuinely empty type/case definitions are
+                        // malformed input but the parser previously dropped
+                        // them silently. Surface as a hard error.
+                        return Err(format!(
+                            "<{}/> empty element is not allowed (need child elements)",
+                            tag
+                        ));
+                    }
+                    _ => {
+                        handle_open_tag(
+                            &tag,
+                            &attrs,
+                            &mut module_stack,
+                            &mut current_struct,
+                            &mut current_enum,
+                            &mut current_bitmask,
+                            &mut current_union,
+                            &mut current_case,
+                        );
+                    }
+                }
+            }
+            Ok(Event::End(ref e)) => {
+                let tag = std::str::from_utf8(e.name().as_ref())
+                    .unwrap_or("")
+                    .to_lowercase();
+
+                match tag.as_str() {
+                    "module" => {
+                        module_stack.pop();
+                    }
+                    "struct" => {
+                        if let Some((name, ext, autoid_hash, members)) = current_struct.take() {
+                            // Fully qualified module path: A::B::C, not just C.
+                            let module = module_stack.join("::");
+                            types.push(RawTypeDef::Struct {
+                                name,
+                                module,
+                                extensibility: ext,
+                                autoid_hash,
+                                members,
+                            });
+                        }
+                    }
+                    "enum" => {
+                        if let Some((name, bit_bound, variants)) = current_enum.take() {
+                            let module = module_stack.join("::");
+                            types.push(RawTypeDef::Enum {
+                                name,
+                                module,
+                                bit_bound,
+                                variants,
+                            });
+                        }
+                    }
+                    "bitmask" => {
+                        if let Some((name, bit_bound, flags)) = current_bitmask.take() {
+                            let module = module_stack.join("::");
+                            types.push(RawTypeDef::Bitmask {
+                                name,
+                                module,
+                                bit_bound,
+                                flags,
+                            });
+                        }
+                    }
+                    "union" => {
+                        if let Some((name, ext, disc_type, disc_try_construct, disc_is_key, cases)) = current_union.take() {
+                            let module = module_stack.join("::");
+                            types.push(RawTypeDef::Union {
+                                name,
+                                module,
+                                extensibility: ext,
+                                discriminator_type: disc_type,
+                                discriminator_try_construct: disc_try_construct,
+                                discriminator_is_key: disc_is_key,
+                                cases,
+                            });
+                        }
+                    }
+                    "case" => {
+                        if let Some((int_labels, name_labels, is_default, Some(member))) = current_case.take() {
+                            if let Some((_, _, _, _, _, ref mut cases)) = current_union {
+                                cases.push(RawCase {
+                                    discriminator_values: int_labels,
+                                    discriminator_name_labels: name_labels,
+                                    is_default,
+                                    member,
+                                });
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(format!("XML parse error: {}", e)),
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    Ok(types)
+}
+
+/// Shared handler for both Start and (non-container) Empty events.
+fn handle_open_tag(
+    tag: &str,
+    attrs: &HashMap<String, String>,
+    module_stack: &mut Vec<String>,
+    current_struct: &mut Option<(String, String, bool, Vec<RawMember>)>,
+    current_enum: &mut Option<(String, u8, Vec<EnumVariant>)>,
+    current_bitmask: &mut Option<(String, u8, Vec<(String, u32)>)>,
+    current_union: &mut Option<(String, String, String, TryConstructKind, bool, Vec<RawCase>)>,
+    current_case: &mut Option<(Vec<i64>, Vec<String>, bool, Option<RawMember>)>,
+) {
+    match tag {
+        "module" => {
+            let name = attrs.get("name").cloned().unwrap_or_default();
+            module_stack.push(name);
+        }
+        "struct" => {
+            let name = attrs.get("name").cloned().unwrap_or_default();
+            // IDL 4.2 / DDS-XTypes v1.3 (7.3.1.2.1.6): a constructed type
+            // with no explicit extensibility annotation is APPENDABLE, not
+            // final. Reference vendors (coredx/cyclone/connext) apply this
+            // default, so a "final" fallback here breaks TypeObject hashes
+            // and assignability for every type file omitting the attribute.
+            let ext = attrs
+                .get("extensibility")
+                .cloned()
+                .unwrap_or_else(|| "appendable".to_string());
+            // autoid="hash" enables IS_AUTOID_HASH on the emitted StructTypeFlag
+            // (DDS-XTypes v1.3 §7.3.1.2).  Any other autoid value is ignored.
+            let autoid_hash = attrs
+                .get("autoid")
+                .map(|v| v.trim().to_lowercase() == "hash")
+                .unwrap_or(false);
+            *current_struct = Some((name, ext, autoid_hash, Vec::new()));
+        }
+        "enum" => {
+            let name = attrs.get("name").cloned().unwrap_or_default();
+            let bit_bound = attrs
+                .get("bitbound")
+                .and_then(|v| v.parse::<u8>().ok())
+                .unwrap_or(32);
+            *current_enum = Some((name, bit_bound, Vec::new()));
+        }
+        "bitmask" => {
+            let name = attrs.get("name").cloned().unwrap_or_default();
+            let bit_bound = attrs
+                .get("bitbound")
+                .and_then(|v| v.parse::<u8>().ok())
+                .unwrap_or(32);
+            *current_bitmask = Some((name, bit_bound, Vec::new()));
+        }
+        "flag" => {
+            // <flag name="FLAG_N" value="N"/> where value is the bit position.
+            if let Some((_, _, ref mut flags)) = current_bitmask {
+                let fname = attrs.get("name").cloned().unwrap_or_default();
+                let position = attrs
+                    .get("value")
+                    .and_then(|v| v.parse::<u32>().ok())
+                    .unwrap_or(flags.len() as u32);
+                flags.push((fname, position));
+            }
+        }
+        "union" => {
+            let name = attrs.get("name").cloned().unwrap_or_default();
+            // Same spec default as struct: absent extensibility attribute
+            // means APPENDABLE (IDL 4.2 / DDS-XTypes v1.3 7.3.1.2.1.6).
+            let ext = attrs
+                .get("extensibility")
+                .cloned()
+                .unwrap_or_else(|| "appendable".to_string());
+            *current_union = Some((name, ext, "int32".to_string(), TryConstructKind::Discard, false, Vec::new()));
+        }
+        "discriminator" => {
+            if let Some((_, _, ref mut disc_type, ref mut disc_tc, ref mut disc_is_key, _)) = current_union {
+                if let Some(t) = attrs.get("type") {
+                    if t == "nonBasic" || t == "nonbasic" {
+                        // Use the referenced type name as the discriminator type string.
+                        if let Some(n) = attrs.get("nonbasictypename") {
+                            *disc_type = n.clone();
+                        }
+                    } else {
+                        *disc_type = t.clone();
+                    }
+                }
+                if let Some(tc) = attrs.get("tryconstruct") {
+                    *disc_tc = try_construct_from_str(tc);
+                }
+                if attrs.get("key").map(|v| v.trim().eq_ignore_ascii_case("true")).unwrap_or(false) {
+                    *disc_is_key = true;
+                }
+            }
+        }
+        "case" => {
+            *current_case = Some((Vec::new(), Vec::new(), false, None));
+        }
+        "casediscriminator" => {
+            if let Some((ref mut int_labels, ref mut name_labels, ref mut is_default, _)) = current_case {
+                if let Some(v) = attrs.get("value") {
+                    if v.trim().eq_ignore_ascii_case("default") {
+                        *is_default = true;
+                    } else if let Ok(parsed) = parse_int_literal(v) {
+                        int_labels.push(parsed);
+                    } else {
+                        // Enum variant name — resolved to an integer value once
+                        // the discriminator type is known in raw_to_descriptor.
+                        name_labels.push(v.trim().to_string());
+                    }
+                }
+            }
+        }
+        "member" => {
+            let member = build_raw_member(attrs);
+            // Precedence: a union case `member` populates the case payload;
+            // otherwise it is appended to the current struct.
+            if let Some((_, _, _, ref mut opt_member)) = current_case {
+                *opt_member = Some(member);
+            } else if let Some((_, _, _, ref mut members)) = current_struct {
+                members.push(member);
+            }
+        }
+        "enumerator" => {
+            if let Some((_, _, ref mut variants)) = current_enum {
+                let name = attrs.get("name").cloned().unwrap_or_default();
+                let value = attrs
+                    .get("value")
+                    .and_then(|v| parse_int_literal(v).ok())
+                    .unwrap_or(variants.len() as i64);
+                let default_literal = attrs
+                    .get("defaultliteral")
+                    .map(|v| v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false);
+                let mut variant = EnumVariant::new(name, value);
+                if default_literal {
+                    variant = variant.with_default_literal();
+                }
+                variants.push(variant);
+            }
+        }
+        _ => {}
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Attribute helpers
+// ---------------------------------------------------------------------------
+
+fn parse_attrs(e: &quick_xml::events::BytesStart) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for attr in e.attributes().flatten() {
+        let key = std::str::from_utf8(attr.key.as_ref())
+            .unwrap_or("")
+            .to_lowercase();
+        // Unescape XML entities in attribute values so `type="string&lt;64&gt;"`
+        // round-trips to `string<64>`. Without this the inline-bound syntax
+        // never matches because the entity stays literal.
+        let val = attr
+            .unescape_value()
+            .map(|cow| cow.into_owned())
+            .unwrap_or_else(|_| String::from_utf8(attr.value.to_vec()).unwrap_or_default());
+        map.insert(key, val);
+    }
+    map
+}
+
+fn build_raw_member(attrs: &HashMap<String, String>) -> RawMember {
+    let name = attrs.get("name").cloned().unwrap_or_default();
+    // DDS-XML uses type="nonBasic" + nonBasicTypeName="ActualType" when the
+    // member type is a user-defined type (enum, struct, union). Resolve to the
+    // actual type name so prim_from_str_or_nested_with_bound can look it up.
+    let raw_type = attrs.get("type").map(|s| s.as_str()).unwrap_or("int32");
+    let type_str = if raw_type.eq_ignore_ascii_case("nonBasic") {
+        attrs
+            .get("nonbasictypename")
+            .cloned()
+            .unwrap_or_else(|| "int32".to_string())
+    } else {
+        raw_type.to_string()
+    };
+    let id = attrs.get("id").and_then(|v| v.parse::<u32>().ok());
+
+    // sequenceMaxLength: present means it is a sequence
+    let sequence_max = attrs
+        .get("sequencemaxlength")
+        .and_then(|v| parse_int_literal(v).ok());
+
+    // arrayDimensions: comma-separated list e.g. "10" or "10,2"
+    let array_dims: Vec<usize> = attrs
+        .get("arraydimensions")
+        .map(|v| {
+            v.split(',')
+                .filter_map(|s| s.trim().parse::<usize>().ok())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let string_max = attrs
+        .get("stringmaxlength")
+        .and_then(|v| v.parse::<usize>().ok());
+
+    let optional = attrs.get("optional").map(|v| v == "true").unwrap_or(false);
+
+    // tryConstruct attribute (DDS-XML: case-insensitive).
+    // Per DDS-XTypes v1.3 §7.2.2.4.1.2 Table 9, absent TryConstruct flags
+    // (both TC1 and TC2 = 0) encode DISCARD, not USE_DEFAULT. The XML
+    // attribute is absent when neither publisher nor subscriber specified a
+    // policy; the absence means the subscriber cannot accommodate a bound
+    // mismatch and must reject the sample.
+    let try_construct = attrs
+        .get("tryconstruct")
+        .map(|v| try_construct_from_str(v))
+        .unwrap_or(TryConstructKind::Discard);
+
+    // hashid="alias" overrides the name used for hash-based member ID
+    // computation (DDS-XTypes §7.3.1.2.1.1). The attribute value is the
+    // canonical name whose FNV-1a hash becomes the member ID.
+    let hashid = attrs.get("hashid").cloned();
+
+    // key="true" marks the member as participating in the DDS instance key
+    // (DDS-XTypes §7.5.1.3). The IS_KEY MemberFlag is set in the emitted
+    // TypeObject so that the key-compatibility check fires during type matching.
+    let is_key = attrs
+        .get("key")
+        .map(|v| v.trim().eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    // mustUnderstand="true" marks the member as @must_understand
+    // (DDS-XTypes §7.6.3.3). IS_MUST_UNDERSTAND is set in the emitted
+    // TypeObject; if a writer sends this member and the reader's type lacks a
+    // member with the same ID, the type pair is structurally incompatible.
+    let is_must_understand = attrs
+        .get("mustunderstand")
+        .map(|v| v.trim().eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    RawMember {
+        name,
+        type_str,
+        id,
+        sequence_max,
+        array_dims,
+        string_max,
+        optional,
+        try_construct,
+        hashid,
+        is_key,
+        is_must_understand,
+    }
+}
+
+/// Map an XML `tryConstruct` attribute value to [`TryConstructKind`].
+///
+/// Accepted values (case-insensitive, leading/trailing whitespace stripped):
+///   `discard`     → [`TryConstructKind::Discard`]
+///   `trim`        → [`TryConstructKind::Trim`]
+///   `use_default` → [`TryConstructKind::UseDefault`]
+///
+/// Any other value (including absent attribute) falls back to `UseDefault`
+/// per DDS-XTypes v1.3 §7.5.1.4.
+fn try_construct_from_str(s: &str) -> TryConstructKind {
+    match s.trim().to_lowercase().as_str() {
+        "discard" => TryConstructKind::Discard,
+        "trim" => TryConstructKind::Trim,
+        "use_default" | "usedefault" => TryConstructKind::UseDefault,
+        _ => TryConstructKind::UseDefault,
+    }
+}
+
+fn parse_int_literal(s: &str) -> Result<i64, String> {
+    let s = s.trim();
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        i64::from_str_radix(hex, 16).map_err(|e| e.to_string())
+    } else {
+        s.parse::<i64>().map_err(|e| e.to_string())
+    }
+}
+
+/// Map a DDS-XML extensibility attribute value to `Extensibility`.
+///
+/// Per OMG DDS-XML specification and IDL 4.2 the recognized values are
+/// "final", "appendable", and "mutable" (case-insensitive). Any other value
+/// falls back to `Appendable` -- the IDL 4.2 / DDS-XTypes v1.3 (7.3.1.2.1.6)
+/// default for constructed types without an explicit annotation.
+fn extensibility_from_str(s: &str) -> Extensibility {
+    match s.to_lowercase().as_str() {
+        "final" => Extensibility::Final,
+        "mutable" => Extensibility::Mutable,
+        _ => Extensibility::Appendable,
+    }
+}
+
+/// Map an `bitBound` (8/16/32) to a HDDS `PrimitiveKind`. Anything outside
+/// the spec range falls back to U32 (the IDL 4.2 default).
+fn bit_bound_to_primitive(bit_bound: u8) -> PrimitiveKind {
+    match bit_bound {
+        8 => PrimitiveKind::U8,
+        16 => PrimitiveKind::U16,
+        _ => PrimitiveKind::U32,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Convert raw type to TypeDescriptor
+// ---------------------------------------------------------------------------
+
+fn raw_to_descriptor(
+    raw: &RawTypeDef,
+    all_types: &[RawTypeDef],
+    by_qualified: &HashMap<String, usize>,
+    by_local: &HashMap<String, usize>,
+) -> Result<TypeDescriptor, String> {
+    match raw {
+        RawTypeDef::Struct {
+            name,
+            module,
+            extensibility,
+            autoid_hash,
+            members,
+        } => {
+            let qualified = if module.is_empty() {
+                name.clone()
+            } else {
+                format!("{}::{}", module, name)
+            };
+            let fields: Result<Vec<FieldDescriptor>, String> = members
+                .iter()
+                .map(|m| {
+                    let td = Arc::new(member_to_type_descriptor(
+                        m,
+                        all_types,
+                        by_qualified,
+                        by_local,
+                    )?);
+                    let mut fd = FieldDescriptor::new(m.name.clone(), td);
+                    if let Some(id) = m.id {
+                        fd = fd.with_id(id);
+                    }
+                    if m.optional {
+                        fd = fd.optional();
+                    }
+                    fd = fd.with_try_construct(m.try_construct);
+                    if let Some(ref alias) = m.hashid {
+                        fd = fd.with_hashid_name(alias.clone());
+                    }
+                    if m.is_key {
+                        fd = fd.with_key();
+                    }
+                    if m.is_must_understand {
+                        fd = fd.with_must_understand();
+                    }
+                    Ok(fd)
+                })
+                .collect();
+            // Map the XML extensibility attribute to the TypeDescriptor enum.
+            // Absent attributes were already defaulted to "appendable" at
+            // parse time (IDL 4.2 / DDS-XTypes v1.3 spec default).
+            let ext = extensibility_from_str(extensibility);
+            let mut td = TypeDescriptor::struct_type(qualified, fields?).with_extensibility(ext);
+            if *autoid_hash {
+                td = td.with_autoid_hash();
+            }
+            Ok(td)
+        }
+        RawTypeDef::Enum {
+            name,
+            module,
+            bit_bound,
+            variants,
+        } => {
+            let qualified = if module.is_empty() {
+                name.clone()
+            } else {
+                format!("{}::{}", module, name)
+            };
+            // Propagate the bit_bound to the underlying CDR width
+            // (F-bitBound). Otherwise vendors which respect a 1-byte
+            // encoding will see 3 bytes of misalignment on every following
+            // field.
+            let enum_desc = EnumDescriptor::new(variants.clone())
+                .with_underlying(bit_bound_to_primitive(*bit_bound));
+            Ok(TypeDescriptor::new(qualified, TypeKind::Enum(enum_desc)))
+        }
+        RawTypeDef::Bitmask {
+            name,
+            module,
+            bit_bound,
+            flags,
+        } => {
+            let qualified = if module.is_empty() {
+                name.clone()
+            } else {
+                format!("{}::{}", module, name)
+            };
+            // Bitmask: each flag at bit position N has value `1 << N`.
+            // Represented as an enum so union discriminator resolution and
+            // type assignability use the same enum path.
+            let variants: Vec<EnumVariant> = flags
+                .iter()
+                .map(|(flag_name, position)| {
+                    EnumVariant::new(flag_name.clone(), 1_i64 << position)
+                })
+                .collect();
+            let enum_desc = EnumDescriptor::new_bitmask(variants)
+                .with_underlying(bit_bound_to_primitive(*bit_bound));
+            Ok(TypeDescriptor::new(qualified, TypeKind::Enum(enum_desc)))
+        }
+        RawTypeDef::Union {
+            name,
+            module,
+            extensibility,
+            discriminator_type,
+            discriminator_try_construct,
+            discriminator_is_key,
+            cases,
+        } => {
+            let qualified = if module.is_empty() {
+                name.clone()
+            } else {
+                format!("{}::{}", module, name)
+            };
+            // Resolve discriminator type — may be a primitive or a defined
+            // type such as an enum (DDS-XML `nonBasic`).
+            let disc_td = Arc::new(prim_from_str_or_nested_with_bound(
+                discriminator_type,
+                None,
+                all_types,
+                by_qualified,
+                by_local,
+            )?);
+            // Separate default case from labeled cases, recording the
+            // default's declaration index among ALL cases so the TypeObject
+            // emission can keep it at its declared slot with its sequential
+            // member id (reference vendors number union members by
+            // declaration order, default case included).
+            let mut default_case: Option<UnionCase> = None;
+            let mut default_case_index: Option<usize> = None;
+            let mut regular_cases: Vec<UnionCase> = Vec::new();
+            for (decl_idx, c) in cases.iter().enumerate() {
+                let case_td = Arc::new(member_to_type_descriptor(
+                    &c.member,
+                    all_types,
+                    by_qualified,
+                    by_local,
+                )?);
+                // Resolve any string-valued caseDiscriminator labels (enum
+                // variant names) to their integer values using the
+                // discriminator enum type.
+                let mut int_labels = c.discriminator_values.clone();
+                if !c.discriminator_name_labels.is_empty() {
+                    if let TypeKind::Enum(ref e) = disc_td.kind {
+                        for label in &c.discriminator_name_labels {
+                            if let Some(v) = e.variant(label) {
+                                int_labels.push(v.value);
+                            }
+                            // Unknown name silently skipped; case will only
+                            // match if other integer labels are provided.
+                        }
+                    }
+                }
+                let mut uc = UnionCase::new(
+                    c.member.name.clone(),
+                    int_labels,
+                    case_td,
+                )
+                .with_try_construct(c.member.try_construct);
+                // Propagate explicit @id(N) / `id` attribute when present so
+                // the TypeObject member_id matches the declared annotation, not
+                // the declaration-order positional index.
+                if let Some(explicit_id) = c.member.id {
+                    uc = uc.with_member_id(explicit_id);
+                }
+                if c.is_default {
+                    default_case = Some(uc);
+                    default_case_index = Some(decl_idx);
+                } else {
+                    regular_cases.push(uc);
+                }
+            }
+            let mut union_desc = UnionDescriptor::new(disc_td, regular_cases)
+                .with_discriminator_try_construct(*discriminator_try_construct);
+            if *discriminator_is_key {
+                union_desc = union_desc.with_discriminator_key();
+            }
+            if let (Some(dc), Some(idx)) = (default_case, default_case_index) {
+                union_desc = union_desc.with_default_at(dc, idx);
+            }
+            let ext = extensibility_from_str(extensibility);
+            Ok(TypeDescriptor::new(qualified, TypeKind::Union(union_desc))
+                .with_extensibility(ext))
+        }
+    }
+}
+
+fn member_to_type_descriptor(
+    m: &RawMember,
+    all_types: &[RawTypeDef],
+    by_qualified: &HashMap<String, usize>,
+    by_local: &HashMap<String, usize>,
+) -> Result<TypeDescriptor, String> {
+    // Array takes priority over sequence
+    if !m.array_dims.is_empty() {
+        let elem_kind = prim_from_str_or_nested_with_bound(
+            &m.type_str,
+            m.string_max,
+            all_types,
+            by_qualified,
+            by_local,
+        )?;
+        // Struct/union elements must be wrapped in Nested so that
+        // descriptor_to_type_identifier_impl can lower them to a Minimal
+        // EquivalenceHash TypeIdentifier (XTypes v1.3 §7.3.4.7).
+        let elem_kind = match &elem_kind.kind {
+            TypeKind::Struct(_) | TypeKind::Union(_) => {
+                TypeDescriptor::new("", TypeKind::Nested(Arc::new(elem_kind)))
+            }
+            _ => elem_kind,
+        };
+        // Build a single flat ArrayDescriptor with all dimensions stored in
+        // `dims` (DDS-XTypes §7.2.2.4.3 array_bound_seq carries all dims).
+        // This replaces the previous nested-Array approach which prevented the
+        // XTypes bridge from emitting a correct multi-dim TypeIdentifier.
+        let dims: Vec<u32> = m.array_dims.iter().map(|&d| d as u32).collect();
+        let arr = ArrayDescriptor::multi_dim(Arc::new(elem_kind), dims);
+        return Ok(TypeDescriptor::new("", TypeKind::Array(arr)));
+    }
+
+    if let Some(seq_max) = m.sequence_max {
+        let elem_kind = prim_from_str_or_nested_with_bound(
+            &m.type_str,
+            m.string_max,
+            all_types,
+            by_qualified,
+            by_local,
+        )?;
+        // Struct/union elements must be wrapped in Nested so that
+        // descriptor_to_type_identifier_impl can lower them to a Minimal
+        // EquivalenceHash TypeIdentifier (XTypes v1.3 §7.3.4.7).  Without
+        // this the outer sequence TypeObject is None and discovery skips the
+        // structural assignability check, causing false OK results.
+        let elem_kind = match &elem_kind.kind {
+            TypeKind::Struct(_) | TypeKind::Union(_) => {
+                TypeDescriptor::new("", TypeKind::Nested(Arc::new(elem_kind)))
+            }
+            _ => elem_kind,
+        };
+        let elem_td = Arc::new(elem_kind);
+        let seq = if seq_max < 0 {
+            SequenceDescriptor::unbounded(elem_td)
+        } else {
+            SequenceDescriptor::bounded(elem_td, seq_max as usize)
+        };
+        return Ok(TypeDescriptor::new("", TypeKind::Sequence(seq)));
+    }
+
+    // Plain scalar or nested user-defined type
+    let td = prim_from_str_or_nested_with_bound(
+        &m.type_str,
+        m.string_max,
+        all_types,
+        by_qualified,
+        by_local,
+    )?;
+    // Struct/union members must be wrapped in Nested so that
+    // descriptor_to_type_identifier_impl can lower them to a Minimal
+    // EquivalenceHash TypeIdentifier (XTypes v1.3 clause 7.3.4.7), exactly
+    // like the sequence/array element paths above. Without this the outer
+    // type's TypeObject is None and NO TypeInformation is announced at all
+    // (driver prints "ERROR: cannot build CompleteTypeObject").
+    let td = match &td.kind {
+        TypeKind::Struct(_) | TypeKind::Union(_) => {
+            TypeDescriptor::new("", TypeKind::Nested(Arc::new(td)))
+        }
+        _ => td,
+    };
+    Ok(td)
+}
+
+fn prim_from_str_or_nested_with_bound(
+    s: &str,
+    string_max: Option<usize>,
+    all_types: &[RawTypeDef],
+    by_qualified: &HashMap<String, usize>,
+    by_local: &HashMap<String, usize>,
+) -> Result<TypeDescriptor, String> {
+    // Strings come with an optional bound (`string<128>` or
+    // `stringMaxLength="128"`). Propagate it (F-string_max) so HDDS can
+    // enforce the bound on the wire instead of silently emitting an
+    // unbounded length.
+    let lower = s.to_lowercase();
+    if lower == "string" || lower.starts_with("string<") {
+        // Inline `string<N>` syntax takes priority if present.
+        let inline_max = parse_bounded_string_inline(s);
+        let max_length = inline_max.or(string_max);
+        return Ok(TypeDescriptor::primitive(
+            "",
+            PrimitiveKind::String { max_length },
+        ));
+    }
+    if lower == "wstring" || lower.starts_with("wstring<") {
+        let inline_max = parse_bounded_wstring_inline(s);
+        let max_length = inline_max.or(string_max);
+        return Ok(TypeDescriptor::primitive(
+            "",
+            PrimitiveKind::WString { max_length },
+        ));
+    }
+
+    // Try primitive
+    if let Ok(pk) = prim_from_str(s) {
+        return Ok(TypeDescriptor::primitive("", pk));
+    }
+
+    // Try looking up as a defined type (enum, struct, union). The qualified
+    // map takes priority; the local map is a fallback for IDL files that
+    // reference types by their bare name. Lookup also normalizes the
+    // module-stripped form so `Test::E1` matches the `E1` we registered
+    // when the type lives in module Test.
+    if let Some(&idx) = by_qualified
+        .get(s)
+        .or_else(|| by_local.get(s))
+        .or_else(|| {
+            // Strip a leading "Test::" / "Foo::" before falling back to the
+            // local map: in DDS-XML the user often writes the unqualified
+            // name but the type was defined inside a module.
+            s.rsplit("::").next().and_then(|tail| by_local.get(tail))
+        })
+    {
+        return raw_to_descriptor(&all_types[idx], all_types, by_qualified, by_local);
+    }
+
+    Err(format!(
+        "unknown type '{}'; available: {}",
+        s,
+        all_types
+            .iter()
+            .map(|t| t.qualified_name())
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
+}
+
+fn parse_bounded_string_inline(s: &str) -> Option<usize> {
+    let lower = s.to_lowercase();
+    if let Some(rest) = lower.strip_prefix("string<") {
+        rest.trim_end_matches('>').parse::<usize>().ok()
+    } else {
+        None
+    }
+}
+
+fn parse_bounded_wstring_inline(s: &str) -> Option<usize> {
+    let lower = s.to_lowercase();
+    if let Some(rest) = lower.strip_prefix("wstring<") {
+        rest.trim_end_matches('>').parse::<usize>().ok()
+    } else {
+        None
+    }
+}
+
+fn prim_from_str(s: &str) -> Result<PrimitiveKind, String> {
+    match s.to_lowercase().as_str() {
+        "boolean" | "bool" => Ok(PrimitiveKind::Bool),
+        "uint8" | "octet" => Ok(PrimitiveKind::U8),
+        "uint16" | "unsigned short" => Ok(PrimitiveKind::U16),
+        "uint32" | "unsigned long" => Ok(PrimitiveKind::U32),
+        "uint64" | "unsigned long long" => Ok(PrimitiveKind::U64),
+        "int8" => Ok(PrimitiveKind::I8),
+        "int16" | "short" => Ok(PrimitiveKind::I16),
+        "int32" | "long" => Ok(PrimitiveKind::I32),
+        "int64" | "long long" => Ok(PrimitiveKind::I64),
+        "float32" | "float" => Ok(PrimitiveKind::F32),
+        "float64" | "double" => Ok(PrimitiveKind::F64),
+        "float128" | "long double" => Ok(PrimitiveKind::LongDouble),
+        "char8" | "char" => Ok(PrimitiveKind::Char),
+        // IDL 4.2 `byte` is an opaque octet, semantically distinct from `uint8`.
+        // DDS-XTypes v1.3 §7.5.1.3 Table 3: TK_BYTE is NOT assignable to TK_UINT8.
+        "byte" => Ok(PrimitiveKind::Byte),
+        "string" => Ok(PrimitiveKind::String { max_length: None }),
+        "wstring" => Ok(PrimitiveKind::WString { max_length: None }),
+        _ => Err(format!("not a primitive: '{}'", s)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nested_modules_qualify_correctly() {
+        let xml = r#"
+            <dds><types>
+              <module name="A">
+                <module name="B">
+                  <struct name="T" extensibility="final">
+                    <member name="x" type="int32"/>
+                  </struct>
+                </module>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "A::B::T").expect("nested resolve");
+        assert_eq!(td.name, "A::B::T");
+    }
+
+    #[test]
+    fn bit_bound_propagates_to_enum_underlying() {
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <enum name="Small" bitBound="8">
+                  <enumerator name="A" value="0"/>
+                  <enumerator name="B" value="1"/>
+                </enum>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::Small").expect("parse enum");
+        match &td.kind {
+            TypeKind::Enum(e) => assert_eq!(e.underlying, PrimitiveKind::U8),
+            k => panic!("expected Enum, got {:?}", k),
+        }
+    }
+
+    #[test]
+    fn bit_bound_defaults_to_u32() {
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <enum name="Color">
+                  <enumerator name="R" value="0"/>
+                </enum>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::Color").expect("parse");
+        match &td.kind {
+            TypeKind::Enum(e) => assert_eq!(e.underlying, PrimitiveKind::U32),
+            k => panic!("expected Enum, got {:?}", k),
+        }
+    }
+
+    #[test]
+    fn string_max_propagates_via_attribute() {
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <struct name="S" extensibility="final">
+                  <member name="x" type="string" stringMaxLength="128"/>
+                </struct>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::S").expect("parse");
+        let f = td.fields().expect("struct")[0].clone();
+        match &f.type_desc.kind {
+            TypeKind::Primitive(PrimitiveKind::String { max_length }) => {
+                assert_eq!(*max_length, Some(128));
+            }
+            k => panic!("expected bounded String, got {:?}", k),
+        }
+    }
+
+    #[test]
+    fn string_max_propagates_via_inline_syntax() {
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <struct name="S" extensibility="final">
+                  <member name="x" type="string&lt;64&gt;"/>
+                </struct>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::S").expect("parse");
+        let f = td.fields().expect("struct")[0].clone();
+        match &f.type_desc.kind {
+            TypeKind::Primitive(PrimitiveKind::String { max_length }) => {
+                assert_eq!(*max_length, Some(64));
+            }
+            k => panic!("expected bounded String, got {:?}", k),
+        }
+    }
+
+    #[test]
+    fn empty_module_does_not_leak_stack() {
+        // A <module name="X"/> by itself used to push and never pop. With
+        // the fix it should round-trip cleanly: a later <struct/> stays at
+        // top level.
+        let xml = r#"
+            <dds><types>
+              <module name="Empty"/>
+              <module name="Real">
+                <struct name="S" extensibility="final">
+                  <member name="x" type="int32"/>
+                </struct>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Real::S").expect("parse");
+        assert_eq!(td.name, "Real::S");
+    }
+
+    #[test]
+    fn local_lookup_first_write_wins() {
+        // Two structs with the same local name in different modules. The
+        // unqualified lookup should return the first one deterministically.
+        let xml = r#"
+            <dds><types>
+              <module name="A">
+                <struct name="T" extensibility="final">
+                  <member name="x" type="int32"/>
+                </struct>
+              </module>
+              <module name="B">
+                <struct name="T" extensibility="final">
+                  <member name="y" type="int32"/>
+                </struct>
+              </module>
+            </types></dds>
+        "#;
+        // Qualified resolution works for both.
+        assert_eq!(parse_type_xml(xml, "A::T").unwrap().name, "A::T");
+        assert_eq!(parse_type_xml(xml, "B::T").unwrap().name, "B::T");
+        // Unqualified picks A (declared first).
+        let td = parse_type_xml(xml, "T").unwrap();
+        assert_eq!(td.name, "A::T");
+    }
+
+    #[test]
+    fn extensibility_attribute_propagates_to_type_descriptor() {
+        // The XML extensibility attribute must flow through into
+        // TypeDescriptor.extensibility so the bridge and CDR layer can
+        // select the correct StructTypeFlag and representation ID.
+        use hdds::dynamic::Extensibility;
+
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <struct name="Final" extensibility="final">
+                  <member name="x" type="int32"/>
+                </struct>
+                <struct name="App" extensibility="appendable">
+                  <member name="x" type="int32"/>
+                </struct>
+                <struct name="Mut" extensibility="mutable">
+                  <member name="x" type="int32"/>
+                </struct>
+              </module>
+            </types></dds>
+        "#;
+
+        let final_td = parse_type_xml(xml, "Test::Final").expect("parse final");
+        assert_eq!(final_td.extensibility, Extensibility::Final);
+
+        let app_td = parse_type_xml(xml, "Test::App").expect("parse appendable");
+        assert_eq!(app_td.extensibility, Extensibility::Appendable);
+
+        let mut_td = parse_type_xml(xml, "Test::Mut").expect("parse mutable");
+        assert_eq!(mut_td.extensibility, Extensibility::Mutable);
+    }
+
+    #[test]
+    fn extensibility_defaults_to_appendable_when_absent() {
+        // IDL 4.2 / DDS-XTypes v1.3 (7.3.1.2.1.6): constructed types with no
+        // explicit extensibility annotation are APPENDABLE. This test used to
+        // pin the (wrong) "final" default, which diverged from the reference
+        // vendors and broke TypeObject hash equivalence.
+        use hdds::dynamic::Extensibility;
+
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <struct name="NoExt">
+                  <member name="x" type="int32"/>
+                </struct>
+                <union name="NoExtU">
+                  <discriminator type="int32"/>
+                  <case><caseDiscriminator value="1"/><member name="x1" type="int32"/></case>
+                </union>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::NoExt").expect("parse");
+        assert_eq!(td.extensibility, Extensibility::Appendable);
+        let ud = parse_type_xml(xml, "Test::NoExtU").expect("parse union");
+        assert_eq!(ud.extensibility, Extensibility::Appendable);
+    }
+
+    #[test]
+    fn union_extensibility_propagates() {
+        use hdds::dynamic::{Extensibility, TypeKind};
+
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <union name="U1" extensibility="appendable">
+                  <discriminator type="uint32"/>
+                  <case><caseDiscriminator value="1"/><member name="x1" type="int32"/></case>
+                </union>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::U1").expect("parse union");
+        assert_eq!(td.extensibility, Extensibility::Appendable);
+        match &td.kind {
+            TypeKind::Union(u) => {
+                assert_eq!(u.cases.len(), 1);
+                assert_eq!(u.cases[0].name, "x1");
+                assert_eq!(u.cases[0].labels, vec![1]);
+            }
+            k => panic!("expected Union, got {:?}", k),
+        }
+    }
+
+    #[test]
+    fn union_default_case_parsed_and_separated() {
+        use hdds::dynamic::TypeKind;
+
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <union name="U2" extensibility="appendable">
+                  <discriminator type="uint32"/>
+                  <case><caseDiscriminator value="5"/><member name="x5" type="uint32"/></case>
+                  <case><caseDiscriminator value="default"/><member name="xd" type="uint32"/></case>
+                </union>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::U2").expect("parse union with default");
+        match &td.kind {
+            TypeKind::Union(u) => {
+                // The labeled case goes into cases; the default goes into default_case.
+                assert_eq!(u.cases.len(), 1, "expected 1 labeled case");
+                assert_eq!(u.cases[0].name, "x5");
+                assert!(u.default_case.is_some(), "expected a default case");
+                assert_eq!(u.default_case.as_ref().unwrap().name, "xd");
+            }
+            k => panic!("expected Union, got {:?}", k),
+        }
+    }
+
+    #[test]
+    fn nonbasic_member_resolves_to_enum_type() {
+        // type="nonBasic" nonBasicTypeName="E1" in a struct member must resolve
+        // to the enum type rather than failing with "unknown type 'nonBasic'".
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <enum name="E1" bitBound="32" extensibility="appendable">
+                  <enumerator name="VAL0" value="0"/>
+                  <enumerator name="VAL1" value="1"/>
+                </enum>
+                <struct name="struct_enum_1" extensibility="mutable">
+                  <member name="x1" type="nonBasic" nonBasicTypeName="E1"/>
+                </struct>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::struct_enum_1").expect("nonBasic member resolve");
+        let fields = td.fields().expect("struct fields");
+        assert_eq!(fields.len(), 1);
+        match &fields[0].type_desc.kind {
+            TypeKind::Enum(e) => assert_eq!(e.variants.len(), 2),
+            k => panic!("expected Enum field, got {:?}", k),
+        }
+    }
+
+    #[test]
+    fn nonbasic_member_try_construct_propagates() {
+        // tryConstruct on a nonBasic member must reach the FieldDescriptor.
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <enum name="E2" bitBound="32" extensibility="appendable">
+                  <enumerator name="VAL0" value="0"/>
+                  <enumerator name="VAL1" value="1" defaultLiteral="true"/>
+                  <enumerator name="VAL2" value="2"/>
+                </enum>
+                <struct name="struct_enum_2_discard" extensibility="mutable">
+                  <member name="x1" type="nonBasic" nonBasicTypeName="E2" tryConstruct="discard"/>
+                </struct>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::struct_enum_2_discard").expect("nonBasic tryConstruct");
+        let fields = td.fields().expect("struct fields");
+        assert_eq!(fields[0].try_construct, TryConstructKind::Discard);
+    }
+
+    #[test]
+    fn nonbasic_union_case_member_resolves() {
+        // type="nonBasic" nonBasicTypeName="E1" in a union case member.
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <enum name="E1" bitBound="32" extensibility="appendable">
+                  <enumerator name="VAL0" value="0"/>
+                  <enumerator name="VAL1" value="1"/>
+                </enum>
+                <union name="union_enum_1">
+                  <discriminator type="uint32"/>
+                  <case>
+                    <caseDiscriminator value="1"/>
+                    <member name="x1" type="nonBasic" nonBasicTypeName="E1"/>
+                  </case>
+                </union>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::union_enum_1").expect("nonBasic union case");
+        match &td.kind {
+            TypeKind::Union(u) => {
+                assert_eq!(u.cases.len(), 1);
+                match &u.cases[0].type_desc.kind {
+                    TypeKind::Enum(e) => assert_eq!(e.variants.len(), 2),
+                    k => panic!("expected Enum case type, got {:?}", k),
+                }
+            }
+            k => panic!("expected Union, got {:?}", k),
+        }
+    }
+
+    #[test]
+    fn nonbasic_discriminator_with_enum_labels_resolve() {
+        // <discriminator type="nonBasic" nonBasicTypeName="E1"/> with
+        // caseDiscriminator values as enum variant names.
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <enum name="E1" bitBound="32" extensibility="appendable">
+                  <enumerator name="VAL0" value="0"/>
+                  <enumerator name="VAL1" value="1"/>
+                  <enumerator name="VAL2" value="2"/>
+                </enum>
+                <union name="union_disc_enum_1">
+                  <discriminator type="nonBasic" nonBasicTypeName="E1"/>
+                  <case><caseDiscriminator value="VAL0"/><member name="x0" type="int32"/></case>
+                  <case><caseDiscriminator value="VAL1"/><member name="x1" type="int32"/></case>
+                  <case><caseDiscriminator value="VAL2"/><member name="x2" type="int32"/></case>
+                </union>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::union_disc_enum_1").expect("enum-disc union resolve");
+        match &td.kind {
+            TypeKind::Union(u) => {
+                assert_eq!(u.cases.len(), 3);
+                // Enum variant names must be resolved to integer labels.
+                assert_eq!(u.cases[0].labels, vec![0_i64]);
+                assert_eq!(u.cases[1].labels, vec![1_i64]);
+                assert_eq!(u.cases[2].labels, vec![2_i64]);
+            }
+            k => panic!("expected Union, got {:?}", k),
+        }
+    }
+
+    #[test]
+    fn autoid_hash_attribute_sets_autoid_hash_on_descriptor() {
+        // `autoid="hash"` on a struct element must propagate TypeDescriptor.autoid_hash=true.
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <struct name="struct_hashid_1" extensibility="final" autoid="hash">
+                  <member name="x1" type="int32"/>
+                </struct>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::struct_hashid_1").expect("autoid hash parse");
+        assert!(td.autoid_hash, "autoid_hash must be true for autoid='hash'");
+    }
+
+    #[test]
+    fn autoid_absent_leaves_autoid_hash_false() {
+        // Struct without autoid attribute must have autoid_hash=false.
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <struct name="S" extensibility="final">
+                  <member name="x1" type="int32"/>
+                </struct>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::S").expect("parse");
+        assert!(!td.autoid_hash, "autoid_hash must be false when autoid is absent");
+    }
+
+    #[test]
+    fn hashid_attribute_propagates_to_field_descriptor() {
+        // `hashid="x1"` on member x2 must propagate to FieldDescriptor.hashid_name="x1".
+        // This is the key XML attribute for ext_autoid_1 (struct_hashid_2.x2 gets
+        // the same hash-ID as struct_hashid_1.x1 via hashid="x1").
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <struct name="struct_hashid_2" extensibility="final" autoid="hash">
+                  <member name="x2" type="int32" hashid="x1"/>
+                </struct>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::struct_hashid_2").expect("parse hashid");
+        assert!(td.autoid_hash, "autoid_hash must be true");
+        let fields = td.fields().expect("struct fields");
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].name, "x2", "field name must stay x2");
+        assert_eq!(
+            fields[0].hashid_name.as_deref(),
+            Some("x1"),
+            "hashid_name must be 'x1'"
+        );
+    }
+
+    #[test]
+    fn hashid_absent_leaves_hashid_name_none() {
+        // Member without hashid attribute must have hashid_name=None.
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <struct name="S" extensibility="final" autoid="hash">
+                  <member name="x1" type="int32"/>
+                </struct>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::S").expect("parse");
+        let fields = td.fields().expect("struct fields");
+        assert!(fields[0].hashid_name.is_none(), "no hashid attr -> hashid_name must be None");
+    }
+
+    #[test]
+    fn multidim_array_parsed_with_flat_dims() {
+        // arrayDimensions="10,2" must produce a single ArrayDescriptor with
+        // dims=[10, 2] and length=20, not a nested Array-of-Array structure.
+        // This allows the XTypes bridge to emit array_bound_seq=[10,2] directly.
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <struct name="int32x10x2" extensibility="final">
+                  <member name="x1" type="int32" arrayDimensions="10,2"/>
+                </struct>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::int32x10x2").expect("parse multidim");
+        let fields = td.fields().expect("struct fields");
+        assert_eq!(fields.len(), 1);
+        match &fields[0].type_desc.kind {
+            TypeKind::Array(arr) => {
+                assert_eq!(arr.dims, vec![10u32, 2u32], "dims must be [10, 2]");
+                assert_eq!(arr.length, 20, "length must be product 10*2=20");
+                // Element must be a plain i32 primitive, not a nested Array.
+                assert!(
+                    matches!(&arr.element_type.kind, TypeKind::Primitive(PrimitiveKind::I32)),
+                    "element type must be i32, not a nested array"
+                );
+            }
+            k => panic!("expected Array, got {:?}", k),
+        }
+    }
+
+    #[test]
+    fn bitmask_parsed_as_enum_with_power_of_two_values() {
+        // <bitmask name="B_32" bitBound="32"> with two flags at positions 0 and 1.
+        // Must be registered so that a union using it as discriminator can resolve it.
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <bitmask name="B_32" bitBound="32">
+                    <flag name="B_FLAG_1" value="0"/>
+                    <flag name="B_FLAG_2" value="1"/>
+                    <flag name="B_FLAG_3" value="2"/>
+                </bitmask>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::B_32").expect("bitmask parse");
+        match &td.kind {
+            TypeKind::Enum(e) => {
+                assert_eq!(e.variants.len(), 3, "expected 3 flags");
+                assert_eq!(e.variants[0].name, "B_FLAG_1");
+                assert_eq!(e.variants[0].value, 1); // 1 << 0
+                assert_eq!(e.variants[1].name, "B_FLAG_2");
+                assert_eq!(e.variants[1].value, 2); // 1 << 1
+                assert_eq!(e.variants[2].name, "B_FLAG_3");
+                assert_eq!(e.variants[2].value, 4); // 1 << 2
+            }
+            k => panic!("expected Enum for bitmask, got {:?}", k),
+        }
+    }
+
+    #[test]
+    fn bitmask_discriminator_union_resolves() {
+        // A union with a bitmask discriminator must load successfully.
+        // Reproduces the OMG xtypes union_uint32_bitmask32 failure pattern.
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <bitmask name="B_16" bitBound="16">
+                    <flag name="B_FLAG_1" value="0"/>
+                    <flag name="B_FLAG_2" value="1"/>
+                </bitmask>
+                <union name="union_bitmask16">
+                  <discriminator type="nonBasic" nonBasicTypeName="B_16"/>
+                  <case><caseDiscriminator value="2"/><member name="x1" type="int16"/></case>
+                  <case><caseDiscriminator value="1"/><member name="x2" type="int32"/></case>
+                </union>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::union_bitmask16").expect("bitmask discriminator union");
+        match &td.kind {
+            TypeKind::Union(u) => {
+                assert_eq!(u.cases.len(), 2, "expected 2 cases");
+                // Discriminator must be an enum (bitmask).
+                assert!(
+                    matches!(&u.discriminator.kind, TypeKind::Enum(_)),
+                    "discriminator must be Enum (bitmask)"
+                );
+            }
+            k => panic!("expected Union, got {:?}", k),
+        }
+    }
+
+    #[test]
+    fn discriminator_key_parsed() {
+        // A union with `key="true"` on the discriminator element must set
+        // discriminator_is_key=true in the UnionDescriptor.
+        // Reproduces the OMG xtypes union_uint32_one_key failure pattern.
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <union name="union_uint32_key">
+                  <discriminator type="uint32" key="true"/>
+                  <case><caseDiscriminator value="2"/><member name="x1" type="int16"/></case>
+                  <case><caseDiscriminator value="1"/><member name="x2" type="int32"/></case>
+                </union>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::union_uint32_key").expect("key discriminator union");
+        match &td.kind {
+            TypeKind::Union(u) => {
+                assert!(u.discriminator_is_key, "discriminator_is_key must be true");
+            }
+            k => panic!("expected Union, got {:?}", k),
+        }
+    }
+
+    #[test]
+    fn discriminator_key_absent_defaults_false() {
+        // A union without key="true" on the discriminator must have
+        // discriminator_is_key=false (the default).
+        let xml = r#"
+            <dds><types>
+              <module name="Test">
+                <union name="union_uint32">
+                  <discriminator type="uint32"/>
+                  <case><caseDiscriminator value="2"/><member name="x1" type="int16"/></case>
+                  <case><caseDiscriminator value="1"/><member name="x2" type="int32"/></case>
+                </union>
+              </module>
+            </types></dds>
+        "#;
+        let td = parse_type_xml(xml, "Test::union_uint32").expect("non-key discriminator union");
+        match &td.kind {
+            TypeKind::Union(u) => {
+                assert!(!u.discriminator_is_key, "discriminator_is_key must be false");
+            }
+            k => panic!("expected Union, got {:?}", k),
+        }
+    }
+}


### PR DESCRIPTION
Adds the signed CLA and the HDDS application code for the DDS-XTypes interoperability tests, per CONTRIBUTING.md and following up with Angel and Gerardo.

- `CLA/CLA_HDDS.md`: signed Contributor License Agreement for HDDS (Naskel).
- `src/rs/HDDS/`: the test_main application driver (Cargo.toml + src). The HDDS engine is consumed as a dependency (github.com/hdds-team/hdds), so no engine/SDK code is checked in, consistent with the other vendors.

HDDS is an independent, clean-room pure-Rust DDS implementation. This supersedes #17 (which targeted master with the CLA only).